### PR TITLE
Add M-key 2D map overlay

### DIFF
--- a/scenes/ui/world_map_overlay.tscn
+++ b/scenes/ui/world_map_overlay.tscn
@@ -1,0 +1,185 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/world_map_overlay.gd" id="1_overlay"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.075, 0.07, 0.065, 0.97)
+border_width_top = 1
+border_width_left = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.35, 0.29, 0.2, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_logs"]
+bg_color = Color(0.035, 0.032, 0.03, 0.92)
+border_width_top = 1
+border_width_left = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.2, 0.17, 0.13, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[node name="WorldMapOverlay" type="CanvasLayer"]
+layer = 20
+script = ExtResource("1_overlay")
+
+[node name="MapRoot" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 0
+
+[node name="DimBackground" type="ColorRect" parent="MapRoot"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0, 0, 0, 0.58)
+
+[node name="MapPanel" type="PanelContainer" parent="MapRoot"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 36.0
+offset_top = 32.0
+offset_right = -36.0
+offset_bottom = -32.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="Margin" type="MarginContainer" parent="MapRoot/MapPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 12
+
+[node name="MainColumn" type="VBoxContainer" parent="MapRoot/MapPanel/Margin"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="HeaderRow" type="HBoxContainer" parent="MapRoot/MapPanel/Margin/MainColumn"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="MapRoot/MapPanel/Margin/MainColumn/HeaderRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.92, 0.84, 0.66, 1)
+theme_override_font_sizes/font_size = 18
+text = "World Map"
+
+[node name="ToggleHint" type="Label" parent="MapRoot/MapPanel/Margin/MainColumn/HeaderRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.58, 0.53, 0.43, 1)
+theme_override_font_sizes/font_size = 12
+text = "M closes"
+vertical_alignment = 1
+
+[node name="MapArea" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn"]
+custom_minimum_size = Vector2(0, 360)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+clip_contents = true
+mouse_filter = 2
+
+[node name="PlaceholderMapBackground" type="ColorRect" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0.14, 0.125, 0.095, 1)
+
+[node name="PlaceholderLabel" type="Label" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -170.0
+offset_top = -12.0
+offset_right = 170.0
+offset_bottom = 12.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.48, 0.44, 0.36, 1)
+theme_override_font_sizes/font_size = 14
+text = "Projected GECS map data will render here"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="RoutesLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="TownsLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="SquadsLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="ButtonsLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="LogsLayer" type="PanelContainer" parent="MapRoot/MapPanel/Margin/MainColumn"]
+custom_minimum_size = Vector2(0, 86)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_styles/panel = SubResource("StyleBoxFlat_logs")
+
+[node name="LogMargin" type="MarginContainer" parent="MapRoot/MapPanel/Margin/MainColumn/LogsLayer"]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 6
+
+[node name="LogPlaceholder" type="Label" parent="MapRoot/MapPanel/Margin/MainColumn/LogsLayer/LogMargin"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.46, 0.38, 1)
+theme_override_font_sizes/font_size = 12
+text = "LogsLayer"
+vertical_alignment = 1

--- a/scenes/worlds/demo_world/gecs_world_map_combat_demo.tscn
+++ b/scenes/worlds/demo_world/gecs_world_map_combat_demo.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Script" path="res://scripts/bootstrap/demo_sim_bootstrap.gd" id="3_bootstrap"]
 [ext_resource type="Script" path="res://scripts/world_sim/nests/nest_placement_marker.gd" id="4_nest_marker"]
 [ext_resource type="Script" path="res://scripts/simulation/fixed_tick_sim_runner.gd" id="5_runner"]
+[ext_resource type="PackedScene" path="res://scenes/ui/world_map_overlay.tscn" id="6_map_overlay"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_floor"]
 size = Vector3(1100, 1, 950)
@@ -61,6 +62,8 @@ world_definition = ExtResource("2_world")
 [node name="FixedTickSimRunner" type="Node" parent="DemoSimBootstrap"]
 script = ExtResource("5_runner")
 target_path = NodePath("..")
+
+[node name="WorldMapOverlay" parent="." instance=ExtResource("6_map_overlay")]
 
 [node name="CameraRig" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 377.61835, 0.6, 114.84003)

--- a/scripts/ui/world_map_overlay.gd
+++ b/scripts/ui/world_map_overlay.gd
@@ -1,0 +1,45 @@
+extends CanvasLayer
+
+class_name WorldMapOverlay
+
+@export var start_open := false
+@export var toggle_keycode := KEY_M
+
+@onready var map_root: Control = $MapRoot
+
+
+func _ready() -> void:
+	add_to_group("world_map_overlay")
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	map_root.visible = start_open
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	var key_event := event as InputEventKey
+	if key_event == null or not key_event.pressed or key_event.echo or key_event.keycode != toggle_keycode:
+		return
+	if _is_text_input_focused():
+		return
+	toggle_map()
+	get_viewport().set_input_as_handled()
+
+
+func open_map() -> void:
+	map_root.visible = true
+
+
+func close_map() -> void:
+	map_root.visible = false
+
+
+func toggle_map() -> void:
+	map_root.visible = not map_root.visible
+
+
+func is_map_open() -> bool:
+	return map_root.visible
+
+
+func _is_text_input_focused() -> bool:
+	var focus_owner := get_viewport().gui_get_focus_owner()
+	return focus_owner is LineEdit or focus_owner is TextEdit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a toggleable world map overlay accessible via the M key. The overlay presents a comprehensive view of the world, displaying routes, towns, squads, and activity logs for better situational awareness. Players can quickly open and close the map during gameplay to check world status and track important information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->