### PR TITLE
Add dev map squad command buttons

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="MyGame"
-run/main_scene="uid://cp73mjas8wdqn"
+run/main_scene="res://scenes/worlds/demo_world/gecs_world_map_combat_demo.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/ui/world_map_overlay.tscn
+++ b/scenes/ui/world_map_overlay.tscn
@@ -91,6 +91,14 @@ theme_override_font_sizes/font_size = 12
 text = "M closes"
 vertical_alignment = 1
 
+[node name="ButtonsLayer" type="MarginContainer" parent="MapRoot/MapPanel/Margin/MainColumn"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_bottom = 0
+
 [node name="MapArea" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn"]
 custom_minimum_size = Vector2(0, 360)
 layout_mode = 2
@@ -156,15 +164,6 @@ grow_vertical = 2
 mouse_filter = 2
 
 [node name="SquadsLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-
-[node name="ButtonsLayer" type="Control" parent="MapRoot/MapPanel/Margin/MainColumn/MapArea"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/scenes/worlds/demo_world/gecs_world_map_combat_demo.tscn
+++ b/scenes/worlds/demo_world/gecs_world_map_combat_demo.tscn
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" path="res://scenes/ui/world_map_overlay.tscn" id="6_map_overlay"]
 [ext_resource type="Script" path="res://scripts/ui/world_map_placement_projector.gd" id="7_map_projector"]
 [ext_resource type="Script" path="res://scripts/ui/world_map_squad_projector.gd" id="8_squad_projector"]
+[ext_resource type="Script" path="res://scripts/ui/world_map_squad_command_panel.gd" id="9_command_panel"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_floor"]
 size = Vector3(1100, 1, 950)
@@ -80,6 +81,12 @@ world_definition = ExtResource("2_world")
 overlay_path = NodePath("../WorldMapOverlay")
 squad_state_source_path = NodePath("../DemoSimBootstrap")
 
+[node name="WorldMapSquadCommandPanel" type="Node" parent="."]
+script = ExtResource("9_command_panel")
+world_definition = ExtResource("2_world")
+overlay_path = NodePath("../WorldMapOverlay")
+squad_state_source_path = NodePath("../DemoSimBootstrap")
+
 [node name="CameraRig" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 377.61835, 0.6, 114.84003)
 
@@ -88,3 +95,5 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 377.61835, 0.6, 114.84003)
 [node name="Camera3D" type="Camera3D" parent="CameraRig/CameraPivot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 24)
 current = true
+
+[connection signal="command_requested" from="WorldMapSquadCommandPanel" to="DemoSimBootstrap/FixedTickSimRunner" method="queue_command"]

--- a/scripts/bootstrap/demo_sim_bootstrap.gd
+++ b/scripts/bootstrap/demo_sim_bootstrap.gd
@@ -295,8 +295,12 @@ func _command_log_from_state(state: Dictionary) -> Array[Dictionary]:
 
 
 func _append_command_log(command_log: Array[Dictionary], command: Dictionary, status: String, message: String) -> void:
+	var log_id := 1
+	if not command_log.is_empty():
+		var previous_entry: Dictionary = command_log[command_log.size() - 1]
+		log_id = int(previous_entry.get("log_id", command_log.size())) + 1
 	command_log.append({
-		"log_id": command_log.size() + 1,
+		"log_id": log_id,
 		"status": status,
 		"command_id": str(command.get("command_id", "")),
 		"action": str(command.get("action", "")),

--- a/scripts/bootstrap/demo_sim_bootstrap.gd
+++ b/scripts/bootstrap/demo_sim_bootstrap.gd
@@ -4,6 +4,7 @@ class_name DemoSimBootstrap
 
 const DEMO_SIM_ENTITY_ID := "demo_sim:state"
 const WORLD_SQUAD_ENTITY_ID := "world_squad:state"
+const MAX_COMMAND_LOG_ENTRIES := 40
 const GECS_WORLD_SCRIPT := preload("res://addons/gecs/ecs/world.gd")
 const GECS_ENTITY_SCRIPT := preload("res://addons/gecs/ecs/entity.gd")
 const DEMO_SIM_STATE_SCRIPT := preload("res://scripts/ecs/components/c_game_demo_sim_state.gd")
@@ -48,6 +49,20 @@ func get_world_squad_state() -> Dictionary:
 	if _world_squad_state_component != null and _world_squad_state_component.has_method("to_state"):
 		return _world_squad_state_component.call("to_state")
 	return {}
+
+
+func apply_sim_commands(commands: Array[Dictionary]) -> void:
+	_ensure_world_squad_state_entity()
+	if _world_squad_state_component == null or not _world_squad_state_component.has_method("apply_state"):
+		return
+	var state := get_world_squad_state()
+	var active_squads: Dictionary = state.get("active_squads", {})
+	var command_log := _command_log_from_state(state)
+	for command in commands:
+		_apply_sim_command(command, active_squads, command_log)
+	state["active_squads"] = active_squads
+	state["command_log"] = command_log
+	_world_squad_state_component.call("apply_state", state)
 
 
 func update_sim(fixed_delta: float) -> void:
@@ -159,6 +174,7 @@ func _initial_world_squad_state() -> Dictionary:
 		"state_id": "world_squads",
 		"squad_index": active_squads.size(),
 		"active_squads": active_squads,
+		"command_log": [],
 	}
 
 
@@ -171,12 +187,142 @@ func _squad_record_from_template(squad_id: String, faction_id: String, template:
 		"faction_id": faction_id,
 		"location": location,
 		"objective_id": "hold_position",
+		"objective_state": "idle",
 		"member_count": member_count,
 		"strength": base_strength + float(member_count) * base_attack_damage,
 		"morale": 1.0,
 		"supplies": _resource_float(template, "food_capacity", 0.0),
 		"state": "idle",
 	}
+
+
+func _apply_sim_command(command: Dictionary, active_squads: Dictionary, command_log: Array[Dictionary]) -> void:
+	var action := str(command.get("action", "")).strip_edges()
+	match action:
+		"set_squad_objective":
+			_apply_set_squad_objective(command, active_squads, command_log)
+		"set_squads_objective":
+			_apply_set_squads_objective(command, active_squads, command_log)
+		"force_encounter":
+			_apply_force_encounter_command(command, active_squads, command_log)
+		"reset_demo_squads":
+			_apply_reset_demo_squads_command(command, active_squads, command_log)
+		_:
+			_append_command_log(command_log, command, "error", "Unknown command action: %s" % action)
+
+
+func _apply_set_squad_objective(command: Dictionary, active_squads: Dictionary, command_log: Array[Dictionary]) -> void:
+	var squad_id := str(command.get("squad_id", "")).strip_edges()
+	if not active_squads.has(squad_id):
+		_append_command_log(command_log, command, "error", "Unknown squad: %s" % squad_id)
+		return
+	var record: Dictionary = active_squads[squad_id]
+	_write_objective_to_squad_record(record, command)
+	active_squads[squad_id] = record
+	_append_command_log(command_log, command, "applied", "Queued objective for %s" % squad_id)
+
+
+func _apply_set_squads_objective(command: Dictionary, active_squads: Dictionary, command_log: Array[Dictionary]) -> void:
+	var squad_ids := _string_array(command.get("squad_ids", []))
+	if squad_ids.is_empty():
+		_append_command_log(command_log, command, "error", "No squads supplied")
+		return
+	var applied_count := 0
+	for squad_id in squad_ids:
+		if not active_squads.has(squad_id):
+			continue
+		var record: Dictionary = active_squads[squad_id]
+		_write_objective_to_squad_record(record, command)
+		active_squads[squad_id] = record
+		applied_count += 1
+	if applied_count <= 0:
+		_append_command_log(command_log, command, "error", "No supplied squads exist")
+		return
+	_append_command_log(command_log, command, "applied", "Queued objective for %d squads" % applied_count)
+
+
+func _apply_force_encounter_command(command: Dictionary, active_squads: Dictionary, command_log: Array[Dictionary]) -> void:
+	var debug_command := command.duplicate(true)
+	debug_command["objective_id"] = "debug_force_encounter"
+	debug_command["debug_only"] = true
+	var squad_ids := _string_array(debug_command.get("squad_ids", []))
+	if squad_ids.is_empty():
+		_append_command_log(command_log, command, "error", "No squads supplied for debug encounter")
+		return
+	var applied_count := 0
+	for squad_id in squad_ids:
+		if not active_squads.has(squad_id):
+			continue
+		var record: Dictionary = active_squads[squad_id]
+		_write_objective_to_squad_record(record, debug_command)
+		active_squads[squad_id] = record
+		applied_count += 1
+	if applied_count <= 0:
+		_append_command_log(command_log, command, "error", "No supplied squads exist for debug encounter")
+		return
+	_append_command_log(command_log, command, "applied", "Recorded debug-only forced encounter placeholder for %d squads" % applied_count)
+
+
+func _apply_reset_demo_squads_command(command: Dictionary, active_squads: Dictionary, command_log: Array[Dictionary]) -> void:
+	var reset_state := _initial_world_squad_state()
+	var reset_squads: Dictionary = reset_state.get("active_squads", {})
+	active_squads.clear()
+	for squad_id in reset_squads.keys():
+		active_squads[squad_id] = reset_squads[squad_id]
+	_append_command_log(command_log, command, "applied", "Reset demo squad records")
+
+
+func _write_objective_to_squad_record(record: Dictionary, command: Dictionary) -> void:
+	record["command_id"] = str(command.get("command_id", "")).strip_edges()
+	record["command_action"] = str(command.get("action", "")).strip_edges()
+	record["objective_id"] = str(command.get("objective_id", "move_to_location")).strip_edges()
+	record["objective_state"] = "queued"
+	record["target_id"] = str(command.get("target_id", "")).strip_edges()
+	record["target_location"] = _command_location(command.get("target_location", Vector3.ZERO))
+	record["debug_only"] = bool(command.get("debug_only", false))
+	record["state"] = str(command.get("squad_state", "commanded")).strip_edges()
+
+
+func _command_log_from_state(state: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var source = state.get("command_log", [])
+	if not (source is Array):
+		return result
+	for entry in source:
+		if entry is Dictionary:
+			result.append(entry.duplicate(true))
+	return result
+
+
+func _append_command_log(command_log: Array[Dictionary], command: Dictionary, status: String, message: String) -> void:
+	command_log.append({
+		"log_id": command_log.size() + 1,
+		"status": status,
+		"command_id": str(command.get("command_id", "")),
+		"action": str(command.get("action", "")),
+		"message": message,
+	})
+	while command_log.size() > MAX_COMMAND_LOG_ENTRIES:
+		command_log.pop_front()
+
+
+func _string_array(value) -> Array[String]:
+	var result: Array[String] = []
+	if not (value is Array):
+		return result
+	for item in value:
+		var text := str(item).strip_edges()
+		if not text.is_empty():
+			result.append(text)
+	return result
+
+
+func _command_location(value) -> Vector3:
+	if value is Vector3:
+		return value
+	if value is Vector2:
+		return Vector3(value.x, 0.0, value.y)
+	return Vector3.ZERO
 
 
 func _world_squad_templates() -> Array[Resource]:

--- a/scripts/bootstrap/demo_sim_bootstrap.gd.uid
+++ b/scripts/bootstrap/demo_sim_bootstrap.gd.uid
@@ -1,0 +1,1 @@
+uid://2ojk7qi2i5ga

--- a/scripts/ecs/components/c_game_world_squad_state.gd
+++ b/scripts/ecs/components/c_game_world_squad_state.gd
@@ -5,12 +5,14 @@ class_name CGameWorldSquadState
 @export var state_id := "world_squads"
 @export var squad_index := 0
 @export var active_squads: Dictionary = {}
+@export var command_log: Array[Dictionary] = []
 
 
 func apply_state(source: Dictionary) -> void:
 	state_id = str(source.get("state_id", state_id))
 	squad_index = int(source.get("squad_index", squad_index))
 	active_squads = (source.get("active_squads", active_squads) as Dictionary).duplicate(true)
+	command_log = _dictionary_array(source.get("command_log", command_log))
 
 
 func to_state() -> Dictionary:
@@ -18,4 +20,15 @@ func to_state() -> Dictionary:
 		"state_id": state_id,
 		"squad_index": squad_index,
 		"active_squads": active_squads.duplicate(true),
+		"command_log": command_log.duplicate(true),
 	}
+
+
+func _dictionary_array(value) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	if not (value is Array):
+		return result
+	for entry in value:
+		if entry is Dictionary:
+			result.append(entry.duplicate(true))
+	return result

--- a/scripts/ui/world_map_overlay.gd
+++ b/scripts/ui/world_map_overlay.gd
@@ -13,6 +13,8 @@ const WORLD_MAP_PROJECTION_SCRIPT := preload("res://scripts/ui/world_map_project
 @onready var towns_layer: Control = $MapRoot/MapPanel/Margin/MainColumn/MapArea/TownsLayer
 @onready var nests_layer: Control = $MapRoot/MapPanel/Margin/MainColumn/MapArea/NestsLayer
 @onready var squads_layer: Control = $MapRoot/MapPanel/Margin/MainColumn/MapArea/SquadsLayer
+@onready var buttons_layer: Control = $MapRoot/MapPanel/Margin/MainColumn/ButtonsLayer
+@onready var logs_layer: Control = $MapRoot/MapPanel/Margin/MainColumn/LogsLayer/LogMargin
 
 
 func _ready() -> void:
@@ -61,6 +63,14 @@ func get_nests_layer() -> Control:
 
 func get_squads_layer() -> Control:
 	return squads_layer
+
+
+func get_buttons_layer() -> Control:
+	return buttons_layer
+
+
+func get_logs_layer() -> Control:
+	return logs_layer
 
 
 func get_map_rect() -> Rect2:

--- a/scripts/ui/world_map_overlay.gd.uid
+++ b/scripts/ui/world_map_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://cs8jlnyanaohy

--- a/scripts/ui/world_map_squad_command_panel.gd
+++ b/scripts/ui/world_map_squad_command_panel.gd
@@ -74,10 +74,20 @@ func _mount_buttons(overlay: Node) -> void:
 	title.add_theme_font_size_override("font_size", 12)
 	title.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	row.add_child(title)
-	row.add_child(_create_button("Send Squad A to Town 1", _request_send_squad_to_town.bind(0, 0)))
-	row.add_child(_create_button("Send Squad B to Town 2", _request_send_squad_to_town.bind(1, 1)))
-	row.add_child(_create_button("Send Both to Fight", _request_send_both_to_fight_location))
-	row.add_child(_create_button("Force Encounter", _request_force_encounter))
+	var squad_ids := _squad_ids()
+	var towns := _town_targets()
+	var first_squad_id := squad_ids[0] if squad_ids.size() > 0 else ""
+	var second_squad_id := squad_ids[1] if squad_ids.size() > 1 else ""
+	var first_town: Dictionary = towns[0].duplicate(true) if towns.size() > 0 else {}
+	var second_town: Dictionary = towns[1].duplicate(true) if towns.size() > 1 else {}
+	var fight_squad_ids: Array[String] = []
+	for index in range(min(2, squad_ids.size())):
+		fight_squad_ids.append(squad_ids[index])
+	var fight_location := _fight_location()
+	row.add_child(_create_button(_send_squad_to_town_label(first_squad_id, first_town, "Send Squad A to Town 1"), _request_send_squad_to_town.bind(first_squad_id, first_town)))
+	row.add_child(_create_button(_send_squad_to_town_label(second_squad_id, second_town, "Send Squad B to Town 2"), _request_send_squad_to_town.bind(second_squad_id, second_town)))
+	row.add_child(_create_button("Send Both to Fight", _request_send_both_to_fight_location.bind(fight_squad_ids, fight_location)))
+	row.add_child(_create_button("Force Encounter", _request_force_encounter.bind(fight_squad_ids, fight_location)))
 	row.add_child(_create_button("Clear/Reset Demo Squads", _request_reset_demo_squads))
 	buttons_layer.add_child(_button_panel)
 
@@ -107,30 +117,27 @@ func _create_button(label: String, handler: Callable) -> Button:
 	return button
 
 
-func _request_send_squad_to_town(squad_index: int, town_index: int) -> void:
-	var squad_ids := _squad_ids()
-	var towns := _town_targets()
-	if squad_index >= squad_ids.size() or town_index >= towns.size():
+func _request_send_squad_to_town(squad_id: String, town: Dictionary) -> void:
+	if squad_id.is_empty() or town.is_empty():
 		append_log_entry(_ui_log("error", "Missing squad or town for command"))
 		return
-	var town: Dictionary = towns[town_index]
+	var town_id := str(town.get("id", "")).strip_edges()
+	var town_name := str(town.get("display_name", "town")).strip_edges()
 	_request_command({
 		"action": "set_squad_objective",
-		"squad_id": squad_ids[squad_index],
+		"squad_id": squad_id,
 		"objective_id": "move_to_location",
-		"target_id": str(town.get("id", "")),
+		"target_id": town_id,
 		"target_location": town.get("location", Vector3.ZERO),
 		"squad_state": "commanded",
-		"label": "Send %s to %s" % [squad_ids[squad_index], str(town.get("display_name", "town"))],
+		"label": "Send %s to %s" % [squad_id, town_name if not town_name.is_empty() else "town"],
 	})
 
 
-func _request_send_both_to_fight_location() -> void:
-	var squad_ids := _squad_ids()
+func _request_send_both_to_fight_location(squad_ids: Array[String], target_location: Vector3) -> void:
 	if squad_ids.size() < 2:
 		append_log_entry(_ui_log("error", "Need two squads for fight command"))
 		return
-	var target_location := _fight_location()
 	_request_command({
 		"action": "set_squads_objective",
 		"squad_ids": squad_ids.slice(0, 2),
@@ -142,8 +149,7 @@ func _request_send_both_to_fight_location() -> void:
 	})
 
 
-func _request_force_encounter() -> void:
-	var squad_ids := _squad_ids()
+func _request_force_encounter(squad_ids: Array[String], target_location: Vector3) -> void:
 	if squad_ids.size() < 2:
 		append_log_entry(_ui_log("error", "Need two squads for force encounter"))
 		return
@@ -152,7 +158,7 @@ func _request_force_encounter() -> void:
 		"squad_ids": squad_ids.slice(0, 2),
 		"objective_id": "debug_force_encounter",
 		"target_id": "debug_force_encounter",
-		"target_location": _fight_location(),
+		"target_location": target_location,
 		"squad_state": "commanded",
 		"debug_only": true,
 		"label": "Debug-only force encounter placeholder",
@@ -184,14 +190,17 @@ func _sync_sim_command_log() -> void:
 	var command_log = squad_state.get("command_log", [])
 	if not (command_log is Array):
 		return
+	var retained_log_keys := {}
 	for entry in command_log:
 		if not (entry is Dictionary):
 			continue
 		var key := "%s:%s:%s" % [str(entry.get("log_id", "")), str(entry.get("command_id", "")), str(entry.get("status", ""))]
+		retained_log_keys[key] = true
 		if _rendered_sim_log_keys.has(key):
 			continue
 		_rendered_sim_log_keys[key] = true
 		append_log_entry(entry)
+	_rendered_sim_log_keys = retained_log_keys
 
 
 func _render_logs() -> void:
@@ -216,6 +225,13 @@ func _squad_ids() -> Array[String]:
 		result.append(str(squad_id))
 	result.sort()
 	return result
+
+
+func _send_squad_to_town_label(squad_id: String, town: Dictionary, fallback: String) -> String:
+	if squad_id.is_empty() or town.is_empty():
+		return fallback
+	var town_name := str(town.get("display_name", "town")).strip_edges()
+	return "Send %s to %s" % [squad_id, town_name if not town_name.is_empty() else "town"]
 
 
 func _active_squads() -> Dictionary:

--- a/scripts/ui/world_map_squad_command_panel.gd
+++ b/scripts/ui/world_map_squad_command_panel.gd
@@ -1,0 +1,357 @@
+extends Node
+
+class_name WorldMapSquadCommandPanel
+
+signal command_requested(command: Dictionary)
+
+const MAX_LOG_LABELS := 10
+
+@export var world_definition: Resource
+@export var overlay_path: NodePath = NodePath("../WorldMapOverlay")
+@export var squad_state_source_path: NodePath = NodePath("../DemoSimBootstrap")
+
+var _overlay: Node
+var _squad_state_source: Node
+var _button_panel: PanelContainer
+var _log_column: VBoxContainer
+var _command_index := 0
+var _rendered_sim_log_keys := {}
+var _ui_log_entries: Array[Dictionary] = []
+
+
+func _ready() -> void:
+	add_to_group("world_map_squad_command_panel")
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	call_deferred("_mount_panel")
+
+
+func _process(_delta: float) -> void:
+	_sync_sim_command_log()
+
+
+func append_log_entry(entry: Dictionary) -> void:
+	_ui_log_entries.append(entry.duplicate(true))
+	while _ui_log_entries.size() > MAX_LOG_LABELS:
+		_ui_log_entries.pop_front()
+	_render_logs()
+
+
+func _mount_panel() -> void:
+	var overlay := _get_overlay()
+	if overlay == null:
+		return
+	_mount_buttons(overlay)
+	_mount_logs(overlay)
+	_sync_sim_command_log()
+
+
+func _mount_buttons(overlay: Node) -> void:
+	var buttons_layer := _get_buttons_layer(overlay)
+	if buttons_layer == null:
+		return
+	if _button_panel != null and is_instance_valid(_button_panel):
+		return
+	_button_panel = PanelContainer.new()
+	_button_panel.name = "SquadCommandPanel"
+	_button_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_button_panel.mouse_filter = Control.MOUSE_FILTER_PASS
+	_button_panel.add_theme_stylebox_override("panel", _panel_style())
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_top", 6)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_bottom", 6)
+	_button_panel.add_child(margin)
+	var row := HFlowContainer.new()
+	row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_theme_constant_override("h_separation", 6)
+	row.add_theme_constant_override("v_separation", 4)
+	margin.add_child(row)
+	var title := Label.new()
+	title.text = "Squad Commands"
+	title.custom_minimum_size = Vector2(110.0, 24.0)
+	title.add_theme_color_override("font_color", Color(0.92, 0.84, 0.66, 1.0))
+	title.add_theme_font_size_override("font_size", 12)
+	title.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	row.add_child(title)
+	row.add_child(_create_button("Send Squad A to Town 1", _request_send_squad_to_town.bind(0, 0)))
+	row.add_child(_create_button("Send Squad B to Town 2", _request_send_squad_to_town.bind(1, 1)))
+	row.add_child(_create_button("Send Both to Fight", _request_send_both_to_fight_location))
+	row.add_child(_create_button("Force Encounter", _request_force_encounter))
+	row.add_child(_create_button("Clear/Reset Demo Squads", _request_reset_demo_squads))
+	buttons_layer.add_child(_button_panel)
+
+
+func _mount_logs(overlay: Node) -> void:
+	var logs_layer := _get_logs_layer(overlay)
+	if logs_layer == null:
+		return
+	if _log_column != null and is_instance_valid(_log_column):
+		return
+	for child in logs_layer.get_children():
+		if child.name == "LogPlaceholder":
+			child.visible = false
+	_log_column = VBoxContainer.new()
+	_log_column.name = "SquadCommandLog"
+	_log_column.add_theme_constant_override("separation", 2)
+	logs_layer.add_child(_log_column)
+	_render_logs()
+
+
+func _create_button(label: String, handler: Callable) -> Button:
+	var button := Button.new()
+	button.text = label
+	button.focus_mode = Control.FOCUS_NONE
+	button.custom_minimum_size = Vector2(0.0, 24.0)
+	button.pressed.connect(handler)
+	return button
+
+
+func _request_send_squad_to_town(squad_index: int, town_index: int) -> void:
+	var squad_ids := _squad_ids()
+	var towns := _town_targets()
+	if squad_index >= squad_ids.size() or town_index >= towns.size():
+		append_log_entry(_ui_log("error", "Missing squad or town for command"))
+		return
+	var town: Dictionary = towns[town_index]
+	_request_command({
+		"action": "set_squad_objective",
+		"squad_id": squad_ids[squad_index],
+		"objective_id": "move_to_location",
+		"target_id": str(town.get("id", "")),
+		"target_location": town.get("location", Vector3.ZERO),
+		"squad_state": "commanded",
+		"label": "Send %s to %s" % [squad_ids[squad_index], str(town.get("display_name", "town"))],
+	})
+
+
+func _request_send_both_to_fight_location() -> void:
+	var squad_ids := _squad_ids()
+	if squad_ids.size() < 2:
+		append_log_entry(_ui_log("error", "Need two squads for fight command"))
+		return
+	var target_location := _fight_location()
+	_request_command({
+		"action": "set_squads_objective",
+		"squad_ids": squad_ids.slice(0, 2),
+		"objective_id": "debug_fight_location",
+		"target_id": "debug_fight_location",
+		"target_location": target_location,
+		"squad_state": "commanded",
+		"label": "Send squads to debug fight location",
+	})
+
+
+func _request_force_encounter() -> void:
+	var squad_ids := _squad_ids()
+	if squad_ids.size() < 2:
+		append_log_entry(_ui_log("error", "Need two squads for force encounter"))
+		return
+	_request_command({
+		"action": "force_encounter",
+		"squad_ids": squad_ids.slice(0, 2),
+		"objective_id": "debug_force_encounter",
+		"target_id": "debug_force_encounter",
+		"target_location": _fight_location(),
+		"squad_state": "commanded",
+		"debug_only": true,
+		"label": "Debug-only force encounter placeholder",
+	})
+
+
+func _request_reset_demo_squads() -> void:
+	_request_command({
+		"action": "reset_demo_squads",
+		"label": "Reset demo squad records",
+	})
+
+
+func _request_command(command: Dictionary) -> void:
+	_command_index += 1
+	var command_id := "map_cmd:%d:%03d" % [Time.get_ticks_msec(), _command_index]
+	command["command_id"] = command_id
+	command_requested.emit(command.duplicate(true))
+	append_log_entry(_ui_log("issued", str(command.get("label", command.get("action", "command"))), command_id, str(command.get("action", ""))))
+
+
+func _sync_sim_command_log() -> void:
+	var source := _get_squad_state_source()
+	if source == null or not source.has_method("get_world_squad_state"):
+		return
+	var squad_state = source.call("get_world_squad_state")
+	if not (squad_state is Dictionary):
+		return
+	var command_log = squad_state.get("command_log", [])
+	if not (command_log is Array):
+		return
+	for entry in command_log:
+		if not (entry is Dictionary):
+			continue
+		var key := "%s:%s:%s" % [str(entry.get("log_id", "")), str(entry.get("command_id", "")), str(entry.get("status", ""))]
+		if _rendered_sim_log_keys.has(key):
+			continue
+		_rendered_sim_log_keys[key] = true
+		append_log_entry(entry)
+
+
+func _render_logs() -> void:
+	if _log_column == null or not is_instance_valid(_log_column):
+		return
+	for child in _log_column.get_children():
+		_log_column.remove_child(child)
+		child.queue_free()
+	for entry in _ui_log_entries:
+		var label := Label.new()
+		label.text = _log_text(entry)
+		label.add_theme_font_size_override("font_size", 11)
+		label.add_theme_color_override("font_color", _log_color(str(entry.get("status", ""))))
+		label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		_log_column.add_child(label)
+
+
+func _squad_ids() -> Array[String]:
+	var result: Array[String] = []
+	var active_squads := _active_squads()
+	for squad_id in active_squads.keys():
+		result.append(str(squad_id))
+	result.sort()
+	return result
+
+
+func _active_squads() -> Dictionary:
+	var source := _get_squad_state_source()
+	if source == null or not source.has_method("get_world_squad_state"):
+		return {}
+	var squad_state = source.call("get_world_squad_state")
+	if not (squad_state is Dictionary):
+		return {}
+	var active_squads = squad_state.get("active_squads", {})
+	return active_squads if active_squads is Dictionary else {}
+
+
+func _town_targets() -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	if world_definition == null:
+		return result
+	var placements = world_definition.get("settlement_placements")
+	if not (placements is Array):
+		return result
+	for placement in placements:
+		if not (placement is Resource):
+			continue
+		var settlement_definition := placement.get("settlement_definition") as Resource
+		var placement_id := _resource_id(placement)
+		result.append({
+			"id": placement_id,
+			"display_name": _settlement_display_name(settlement_definition, placement_id),
+			"location": _placement_world_position(placement),
+		})
+	return result
+
+
+func _fight_location() -> Vector3:
+	var towns := _town_targets()
+	if towns.size() >= 2:
+		var first: Vector3 = towns[0].get("location", Vector3.ZERO)
+		var second: Vector3 = towns[1].get("location", Vector3.ZERO)
+		return first.lerp(second, 0.5)
+	return Vector3.ZERO
+
+
+func _get_overlay() -> Node:
+	if _overlay != null and is_instance_valid(_overlay):
+		return _overlay
+	if overlay_path == NodePath():
+		return null
+	_overlay = get_node_or_null(overlay_path)
+	return _overlay
+
+
+func _get_squad_state_source() -> Node:
+	if _squad_state_source != null and is_instance_valid(_squad_state_source):
+		return _squad_state_source
+	if squad_state_source_path == NodePath():
+		return null
+	_squad_state_source = get_node_or_null(squad_state_source_path)
+	return _squad_state_source
+
+
+func _get_buttons_layer(overlay: Node) -> Control:
+	if overlay.has_method("get_buttons_layer"):
+		return overlay.call("get_buttons_layer") as Control
+	return null
+
+
+func _get_logs_layer(overlay: Node) -> Control:
+	if overlay.has_method("get_logs_layer"):
+		return overlay.call("get_logs_layer") as Control
+	return null
+
+
+func _placement_world_position(placement: Resource) -> Vector3:
+	var transform_value = placement.get("world_transform")
+	if transform_value is Transform3D:
+		var world_transform: Transform3D = transform_value
+		return world_transform.origin
+	var settlement_definition := placement.get("settlement_definition") as Resource
+	if settlement_definition != null:
+		var position_value = settlement_definition.get("world_position")
+		if position_value is Vector3:
+			return position_value
+	return Vector3.ZERO
+
+
+func _settlement_display_name(settlement_definition: Resource, fallback: String) -> String:
+	var display_name := str(settlement_definition.get("display_name")).strip_edges() if settlement_definition != null else ""
+	if not display_name.is_empty():
+		return display_name
+	return fallback.capitalize()
+
+
+func _resource_id(resource: Resource) -> String:
+	if resource != null and resource.has_method("get_id"):
+		return str(resource.call("get_id")).strip_edges()
+	return ""
+
+
+func _ui_log(status: String, message: String, command_id := "", action := "") -> Dictionary:
+	return {
+		"status": status,
+		"command_id": command_id,
+		"action": action,
+		"message": message,
+	}
+
+
+func _log_text(entry: Dictionary) -> String:
+	var status := str(entry.get("status", "log")).to_upper()
+	var action := str(entry.get("action", ""))
+	var message := str(entry.get("message", ""))
+	return "[%s] %s%s" % [status, message, " (%s)" % action if not action.is_empty() else ""]
+
+
+func _log_color(status: String) -> Color:
+	match status:
+		"issued":
+			return Color(0.78, 0.72, 0.58, 1.0)
+		"applied":
+			return Color(0.42, 0.9, 0.52, 1.0)
+		"error":
+			return Color(1.0, 0.34, 0.22, 1.0)
+		_:
+			return Color(0.62, 0.58, 0.5, 1.0)
+
+
+func _panel_style() -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.035, 0.032, 0.03, 0.94)
+	style.border_color = Color(0.35, 0.29, 0.2, 1.0)
+	style.border_width_top = 1
+	style.border_width_left = 1
+	style.border_width_right = 1
+	style.border_width_bottom = 1
+	style.corner_radius_top_left = 3
+	style.corner_radius_top_right = 3
+	style.corner_radius_bottom_right = 3
+	style.corner_radius_bottom_left = 3
+	return style

--- a/scripts/ui/world_map_squad_command_panel.gd.uid
+++ b/scripts/ui/world_map_squad_command_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://cnr2f5jw30dqk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-map squad command panel to issue and batch squad orders.
  * Bounded, deduplicated command log that displays issued commands and statuses.

* **Gameplay**
  * Demo simulation now accepts and applies issued commands (single- or multi-squad objectives, debug forced-encounters, and demo reset). Errors are logged when commands fail.

* **UI**
  * Map button layer reorganized; overlay now exposes button and log layers for clearer interaction.

* **Default Launch**
  * Project opens the demo world map scene by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->