### PR TITLE
Add headless BattleSim encounter resolver

### DIFF
--- a/scripts/bootstrap/demo_sim_bootstrap.gd
+++ b/scripts/bootstrap/demo_sim_bootstrap.gd
@@ -12,11 +12,27 @@ const DEFAULT_ARRIVAL_THRESHOLD := 2.0
 const DEFAULT_ENCOUNTER_RANGE := 30.0
 const DEFAULT_SPATIAL_BIN_SIZE := 60.0
 const DEFAULT_HOSTILE_THRESHOLD := -50
+const DEFAULT_RESOLUTION_TICKS := 1
+const DEFAULT_ENCOUNTER_REPEAT_COOLDOWN_TICKS := 30
 const GECS_WORLD_SCRIPT := preload("res://addons/gecs/ecs/world.gd")
 const GECS_ENTITY_SCRIPT := preload("res://addons/gecs/ecs/entity.gd")
 const DEMO_SIM_STATE_SCRIPT := preload("res://scripts/ecs/components/c_game_demo_sim_state.gd")
 const WORLD_SQUAD_STATE_SCRIPT := preload("res://scripts/ecs/components/c_game_world_squad_state.gd")
 const WORLD_ENCOUNTER_STATE_SCRIPT := preload("res://scripts/ecs/components/c_game_world_encounter_state.gd")
+const POPULATION_RECORD_SCRIPT := preload("res://scripts/ecs/components/c_game_population_record.gd")
+const BATTLE_SIM_SCRIPT := preload("res://scripts/sim/battle/battle_sim.gd")
+const LIFE_STATE_ALIVE := 0
+const LIFE_STATE_DYING := 5
+const ATTRIBUTE_STRENGTH := "attribute.strength"
+const ATTRIBUTE_PERCEPTION := "attribute.perception"
+const ATTRIBUTE_DEXTERITY := "attribute.dexterity"
+const ATTRIBUTE_TOUGHNESS := "attribute.toughness"
+const ATTRIBUTE_ENDURANCE := "attribute.endurance"
+const COMBAT_SWORDS_ONE_HANDED := "combat.swords_one_handed"
+const COMBAT_AXES_ONE_HANDED := "combat.axes_one_handed"
+const COMBAT_DAGGERS := "combat.daggers"
+const COMBAT_UNARMED := "combat.unarmed"
+const COMBAT_SHIELDS := "combat.shields"
 
 @export var world_definition: Resource
 
@@ -35,6 +51,7 @@ func _ready() -> void:
 	_ensure_world()
 	_ensure_state_entity()
 	_ensure_world_squad_state_entity()
+	_ensure_demo_population_records()
 	_ensure_world_encounter_state_entity()
 	_sim_runner = _find_sim_runner()
 
@@ -98,6 +115,7 @@ func update_sim(fixed_delta: float) -> void:
 	if _ecs_world != null and _ecs_world.has_method("process"):
 		_ecs_world.call("process", fixed_delta)
 	_advance_squad_objectives(fixed_delta)
+	_resolve_squad_encounters()
 	_detect_squad_encounters()
 
 
@@ -189,6 +207,112 @@ func _reset_world_encounter_state() -> void:
 		_world_encounter_state_component.call("apply_state", _initial_world_encounter_state())
 
 
+func _ensure_demo_population_records() -> void:
+	_ensure_world_squad_state_entity()
+	if _world_squad_state_component == null:
+		return
+	var state := get_world_squad_state()
+	var active_squads = state.get("active_squads", {})
+	if active_squads is Dictionary:
+		_ensure_demo_population_records_for_squads(active_squads, false)
+
+
+func _ensure_demo_population_records_for_squads(active_squads: Dictionary, overwrite_existing: bool) -> void:
+	_ensure_world()
+	if _ecs_world == null:
+		return
+	for squad_id in active_squads.keys():
+		var record = active_squads[squad_id]
+		if not (record is Dictionary):
+			continue
+		var squad_record: Dictionary = record
+		var member_ids := _string_array(squad_record.get("member_ids", []))
+		for member_index in range(member_ids.size()):
+			_upsert_demo_population_record(squad_record, member_ids[member_index], member_index, overwrite_existing)
+
+
+func _upsert_demo_population_record(squad_record: Dictionary, member_id: String, member_index: int, overwrite_existing: bool) -> void:
+	var actor_id := member_id.strip_edges()
+	if actor_id.is_empty():
+		return
+	var entity = _find_entity_by_id(_population_entity_id(actor_id))
+	if entity == null:
+		entity = GECS_ENTITY_SCRIPT.new()
+		entity.name = _population_entity_node_name(actor_id)
+		entity.id = _population_entity_id(actor_id)
+		_ecs_world.call("add_entity", entity, [POPULATION_RECORD_SCRIPT.new()])
+	elif not overwrite_existing:
+		var existing_component = entity.call("get_component", POPULATION_RECORD_SCRIPT)
+		if existing_component != null:
+			return
+	var component = entity.call("get_component", POPULATION_RECORD_SCRIPT)
+	if component != null and component.has_method("apply_record"):
+		component.call("apply_record", _demo_population_record_from_squad(squad_record, actor_id, member_index))
+
+
+func _demo_population_record_from_squad(squad_record: Dictionary, member_id: String, member_index: int) -> Dictionary:
+	var max_hp := maxf(float(squad_record.get("max_hp", 100.0)), 1.0)
+	var max_blood := 5.0
+	return {
+		"actor_id": member_id,
+		"stable_id": member_id,
+		"settlement_id": "",
+		"generation_source": "demo_world_squad",
+		"generation_index": member_index,
+		"member_name": "%s %02d" % [str(squad_record.get("member_name_prefix", "Squad Member")), member_index + 1],
+		"faction_id": str(squad_record.get("faction_id", "")),
+		"squad_name": str(squad_record.get("squad_id", "")),
+		"role_id": "squad_member",
+		"hostile_faction_ids": _string_array(squad_record.get("hostile_faction_ids", [])),
+		"combat_stance": int(squad_record.get("combat_stance", 1)),
+		"base_color": squad_record.get("base_color", Color(0.62, 0.62, 0.62, 1.0)),
+		"skill_levels": _demo_member_skill_levels(squad_record, member_index),
+		"traits": {"demo_squad_member": true},
+		"personality": {},
+		"life_state": LIFE_STATE_ALIVE,
+		"hp": max_hp,
+		"max_hp": max_hp,
+		"blood": max_blood,
+		"max_blood": max_blood,
+		"base_attack_damage": maxf(float(squad_record.get("base_attack_damage", 0.0)), 0.0),
+		"base_dodge_chance": 0.0,
+		"base_block_chance": 0.0,
+		"realization_state": "ledger",
+		"ledger_activity_state": "squad_ready",
+		"last_world_position": _record_location(squad_record),
+		"last_world_position_initialized": true,
+		"important": false,
+	}
+
+
+func _demo_member_skill_levels(squad_record: Dictionary, member_index: int) -> Dictionary:
+	var base_attack := maxf(float(squad_record.get("base_attack_damage", 10.0)), 1.0)
+	var base_level := maxi(1, int(round(base_attack * 0.55)))
+	var variance := member_index % 3
+	var stance_bonus := 1 if int(squad_record.get("combat_stance", 1)) == 0 else 0
+	var weapon_level := base_level + variance + stance_bonus
+	return {
+		COMBAT_SWORDS_ONE_HANDED: weapon_level,
+		COMBAT_AXES_ONE_HANDED: maxi(1, weapon_level - 2),
+		COMBAT_DAGGERS: maxi(1, weapon_level - 3),
+		COMBAT_UNARMED: maxi(1, base_level - 3),
+		COMBAT_SHIELDS: maxi(1, base_level - 1),
+		ATTRIBUTE_STRENGTH: base_level + stance_bonus,
+		ATTRIBUTE_PERCEPTION: base_level + 1,
+		ATTRIBUTE_DEXTERITY: base_level + variance,
+		ATTRIBUTE_TOUGHNESS: base_level,
+		ATTRIBUTE_ENDURANCE: base_level,
+	}
+
+
+func _population_entity_id(actor_id: String) -> String:
+	return "population:%s" % actor_id
+
+
+func _population_entity_node_name(actor_id: String) -> String:
+	return "Population_%s" % _safe_node_name(actor_id)
+
+
 func _find_entity_by_id(entity_id: String):
 	var registry = _ecs_world.get("entity_id_registry")
 	if registry is Dictionary:
@@ -237,6 +361,9 @@ func _initial_world_encounter_state() -> Dictionary:
 		"encounter_range": DEFAULT_ENCOUNTER_RANGE,
 		"spatial_bin_size": DEFAULT_SPATIAL_BIN_SIZE,
 		"hostile_threshold": DEFAULT_HOSTILE_THRESHOLD,
+		"default_resolution_ticks": DEFAULT_RESOLUTION_TICKS,
+		"encounter_repeat_cooldown_ticks": DEFAULT_ENCOUNTER_REPEAT_COOLDOWN_TICKS,
+		"recent_pair_cooldowns": {},
 		"encounter_log": [],
 	}
 
@@ -245,8 +372,10 @@ func _squad_record_from_template(squad_id: String, faction_id: String, template:
 	var member_count := _resource_int(template, "member_count", 1)
 	var base_strength := _resource_float(template, "base_strength", 0.0)
 	var base_attack_damage := _resource_float(template, "base_attack_damage", 0.0)
+	var member_ids := _member_ids_for_squad_template(squad_id, template, member_count)
 	return {
 		"squad_id": squad_id,
+		"template_id": _resource_id(template),
 		"faction_id": faction_id,
 		"location": location,
 		"objective_id": "hold_position",
@@ -260,7 +389,15 @@ func _squad_record_from_template(squad_id: String, faction_id: String, template:
 		"active_encounter_id": "",
 		"last_encounter_id": "",
 		"member_count": member_count,
+		"member_ids": member_ids,
+		"member_name_prefix": _resource_string(template, "member_name_prefix", "Squad Member"),
 		"strength": base_strength + float(member_count) * base_attack_damage,
+		"base_strength": base_strength,
+		"base_attack_damage": base_attack_damage,
+		"max_hp": _resource_float(template, "max_hp", 100.0),
+		"combat_stance": _resource_int(template, "combat_stance", 1),
+		"hostile_faction_ids": _resource_string_array(template, "hostile_faction_ids"),
+		"base_color": template.get("base_color") if template != null else Color(0.62, 0.62, 0.62, 1.0),
 		"morale": 1.0,
 		"supplies": _resource_float(template, "food_capacity", 0.0),
 		"state": "idle",
@@ -340,6 +477,7 @@ func _apply_reset_demo_squads_command(command: Dictionary, active_squads: Dictio
 	active_squads.clear()
 	for squad_id in reset_squads.keys():
 		active_squads[squad_id] = reset_squads[squad_id]
+	_ensure_demo_population_records_for_squads(active_squads, true)
 	_append_command_log(command_log, command, "applied", "Reset demo squad records")
 
 
@@ -434,6 +572,275 @@ func _complete_squad_arrival(record: Dictionary, target_location: Vector3, comma
 	_append_command_log(command_log, _command_from_squad_record(record), "arrived", "Squad arrived at %s" % str(record.get("target_id", record.get("squad_id", "target"))))
 
 
+func _resolve_squad_encounters() -> void:
+	if _world_squad_state_component == null or not _world_squad_state_component.has_method("apply_state"):
+		return
+	if _world_encounter_state_component == null or not _world_encounter_state_component.has_method("apply_state"):
+		return
+	var squad_state := get_world_squad_state()
+	var active_squads = squad_state.get("active_squads", {})
+	if not (active_squads is Dictionary):
+		return
+	var encounter_state := get_world_encounter_state()
+	var encounters_by_id := _dictionary_from_state(encounter_state, "encounters_by_id")
+	var active_pair_keys := _dictionary_from_state(encounter_state, "active_pair_keys")
+	var recent_pair_cooldowns := _dictionary_from_state(encounter_state, "recent_pair_cooldowns")
+	var encounter_log := _encounter_log_from_state(encounter_state)
+	var current_tick := _current_tick_count()
+	var default_resolution_ticks := maxi(0, int(encounter_state.get("default_resolution_ticks", DEFAULT_RESOLUTION_TICKS)))
+	var repeat_cooldown_ticks := maxi(0, int(encounter_state.get("encounter_repeat_cooldown_ticks", DEFAULT_ENCOUNTER_REPEAT_COOLDOWN_TICKS)))
+	var squads_changed := false
+	var encounters_changed := _decrement_recent_pair_cooldowns(recent_pair_cooldowns)
+	for encounter_id_value in encounters_by_id.keys():
+		var encounter_id := str(encounter_id_value)
+		var encounter = encounters_by_id[encounter_id_value]
+		if not (encounter is Dictionary):
+			continue
+		var encounter_record: Dictionary = encounter
+		var status := str(encounter_record.get("status", "")).strip_edges()
+		if status == "engaged":
+			encounter_record["status"] = "resolving"
+			encounter_record["resolution_ticks_remaining"] = int(encounter_record.get("resolution_ticks_remaining", default_resolution_ticks))
+			_append_encounter_log(encounter_log, "resolving", encounter_id, str(encounter_record.get("pair_key", "")), "Started resolving %s" % encounter_id)
+			status = "resolving"
+			encounters_changed = true
+		if status != "resolving":
+			encounters_by_id[encounter_id] = encounter_record
+			continue
+		var resolution_ticks_remaining := maxi(0, int(encounter_record.get("resolution_ticks_remaining", default_resolution_ticks)) - 1)
+		encounter_record["resolution_ticks_remaining"] = resolution_ticks_remaining
+		if resolution_ticks_remaining > 0:
+			encounters_by_id[encounter_id] = encounter_record
+			encounters_changed = true
+			continue
+		if _resolve_encounter_record(encounter_record, active_squads, active_pair_keys, recent_pair_cooldowns, encounter_log, current_tick, repeat_cooldown_ticks):
+			encounters_by_id[encounter_id] = encounter_record
+			squads_changed = true
+			encounters_changed = true
+		else:
+			encounters_by_id[encounter_id] = encounter_record
+	if squads_changed:
+		squad_state["active_squads"] = active_squads
+		_world_squad_state_component.call("apply_state", squad_state)
+	if encounters_changed:
+		encounter_state["encounters_by_id"] = encounters_by_id
+		encounter_state["active_pair_keys"] = active_pair_keys
+		encounter_state["recent_pair_cooldowns"] = recent_pair_cooldowns
+		encounter_state["default_resolution_ticks"] = default_resolution_ticks
+		encounter_state["encounter_repeat_cooldown_ticks"] = repeat_cooldown_ticks
+		encounter_state["encounter_log"] = encounter_log
+		_world_encounter_state_component.call("apply_state", encounter_state)
+
+
+func _resolve_encounter_record(encounter_record: Dictionary, active_squads: Dictionary, active_pair_keys: Dictionary, recent_pair_cooldowns: Dictionary, encounter_log: Array[Dictionary], current_tick: int, repeat_cooldown_ticks: int) -> bool:
+	var squad_ids := _string_array(encounter_record.get("squad_ids", []))
+	if squad_ids.size() < 2:
+		return false
+	var squad_a_id := squad_ids[0]
+	var squad_b_id := squad_ids[1]
+	if not active_squads.has(squad_a_id) or not active_squads.has(squad_b_id):
+		return false
+	var squad_a = active_squads[squad_a_id]
+	var squad_b = active_squads[squad_b_id]
+	if not (squad_a is Dictionary) or not (squad_b is Dictionary):
+		return false
+	var squad_a_record: Dictionary = squad_a
+	var squad_b_record: Dictionary = squad_b
+	var encounter_id := str(encounter_record.get("encounter_id", ""))
+	var pair_key := str(encounter_record.get("pair_key", _squad_pair_key(squad_a_id, squad_b_id))).strip_edges()
+	var squad_a_payload := _battle_participant_payload(squad_a_record)
+	var squad_b_payload := _battle_participant_payload(squad_b_record)
+	var battle_result: Dictionary = BATTLE_SIM_SCRIPT.resolve_encounter(encounter_record, squad_a_payload, squad_b_payload, _battle_sim_config(encounter_record, current_tick))
+	_apply_member_casualties_to_population_records(battle_result)
+	_apply_battle_result_to_squad_record(squad_a_record, battle_result, encounter_id)
+	_apply_battle_result_to_squad_record(squad_b_record, battle_result, encounter_id)
+	active_squads[squad_a_id] = squad_a_record
+	active_squads[squad_b_id] = squad_b_record
+	encounter_record["status"] = "resolved"
+	encounter_record["resolved_tick"] = current_tick
+	encounter_record["resolution_ticks_remaining"] = 0
+	encounter_record["battle_result"] = battle_result
+	encounter_record["is_debug_forced"] = bool(encounter_record.get("is_debug_forced", encounter_record.get("debug_only", false)))
+	if not pair_key.is_empty():
+		active_pair_keys.erase(pair_key)
+		if repeat_cooldown_ticks > 0:
+			recent_pair_cooldowns[pair_key] = repeat_cooldown_ticks
+	_append_encounter_log(encounter_log, "resolved", encounter_id, pair_key, str(battle_result.get("summary", "Resolved encounter %s" % encounter_id)))
+	return true
+
+
+func _battle_sim_config(encounter_record: Dictionary, current_tick: int) -> Dictionary:
+	var seed_text := "%s|%s|%s" % [_world_definition_id(), str(encounter_record.get("encounter_id", "")), str(encounter_record.get("created_tick", 0))]
+	return {
+		"seed": seed_text,
+		"current_tick": current_tick,
+	}
+
+
+func _battle_participant_payload(squad_record: Dictionary) -> Dictionary:
+	var payload := squad_record.duplicate(true)
+	var member_records := _resolve_squad_member_records(squad_record)
+	if not member_records.is_empty():
+		payload["member_records"] = member_records
+		payload["member_records_are_canonical"] = true
+	return payload
+
+
+func _resolve_squad_member_records(squad_record: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for member_id in _string_array(squad_record.get("member_ids", [])):
+		var record := _population_record_for_member_id(member_id)
+		if record.is_empty():
+			continue
+		result.append(record)
+	return result
+
+
+func _population_record_for_member_id(member_id: String) -> Dictionary:
+	var component = _population_record_component_for_member_id(member_id)
+	if component != null and component.has_method("to_record"):
+		return component.call("to_record")
+	return {}
+
+
+func _population_record_component_for_member_id(member_id: String):
+	var actor_id := member_id.strip_edges()
+	if actor_id.is_empty() or _ecs_world == null:
+		return null
+	var entity = _find_entity_by_id(_population_entity_id(actor_id))
+	if entity == null:
+		return null
+	return entity.call("get_component", POPULATION_RECORD_SCRIPT)
+
+
+func _apply_member_casualties_to_population_records(battle_result: Dictionary) -> void:
+	var member_casualties = battle_result.get("member_casualties", {})
+	if not (member_casualties is Dictionary):
+		return
+	for squad_id in member_casualties.keys():
+		var entries = member_casualties[squad_id]
+		if not (entries is Array):
+			continue
+		for entry in entries:
+			if entry is Dictionary:
+				_apply_member_casualty_to_population_record(entry)
+
+
+func _apply_member_casualty_to_population_record(casualty: Dictionary) -> void:
+	var member_id := str(casualty.get("member_id", casualty.get("actor_id", ""))).strip_edges()
+	var component = _population_record_component_for_member_id(member_id)
+	if component == null or not component.has_method("to_record") or not component.has_method("apply_record"):
+		return
+	var record: Dictionary = component.call("to_record")
+	var life_state := int(casualty.get("life_state", LIFE_STATE_DYING))
+	record["life_state"] = life_state
+	var max_hp := float(record.get("max_hp", 0.0))
+	if max_hp > 0.0:
+		record["hp"] = 0.0 if life_state != LIFE_STATE_ALIVE else clampf(float(record.get("hp", max_hp)), 0.0, max_hp)
+	var max_blood := float(record.get("max_blood", 0.0))
+	if max_blood > 0.0:
+		record["blood"] = minf(float(record.get("blood", max_blood)), max_blood * 0.35)
+	component.call("apply_record", record)
+
+
+func _apply_battle_result_to_squad_record(record: Dictionary, battle_result: Dictionary, encounter_id: String) -> void:
+	var squad_id := str(record.get("squad_id", ""))
+	var old_member_count := maxi(0, int(record.get("member_count", 0)))
+	var profile := _battle_profile_for_squad(battle_result, squad_id)
+	var used_canonical_members := bool(profile.get("member_records_used", false)) and bool(profile.get("member_records_are_canonical", false))
+	var casualties := clampi(int(_value_for_squad(battle_result.get("casualties", {}), squad_id, 0)), 0, old_member_count)
+	var next_member_count := _combat_capable_member_count(record) if used_canonical_members else maxi(0, old_member_count - casualties)
+	var survivor_ratio := float(next_member_count) / maxf(float(old_member_count), 1.0)
+	record["member_count"] = next_member_count
+	if used_canonical_members:
+		record["strength"] = _remaining_member_power(profile, battle_result, squad_id, next_member_count)
+	else:
+		record["strength"] = maxf(float(record.get("strength", 0.0)) * survivor_ratio, 0.0)
+	var morale_delta := float(_value_for_squad(battle_result.get("morale_delta", {}), squad_id, 0.0))
+	var current_morale := float(record.get("morale", 1.0))
+	if current_morale > 1.5:
+		morale_delta *= 100.0
+	record["morale"] = maxf(current_morale + morale_delta, 0.0)
+	var supplies_delta := float(_value_for_squad(battle_result.get("supplies_delta", {}), squad_id, 0.0))
+	record["supplies"] = maxf(float(record.get("supplies", 0.0)) + supplies_delta, 0.0)
+	record["active_encounter_id"] = ""
+	record["last_encounter_id"] = encounter_id
+	record["debug_only"] = false
+	record["target_location"] = _record_location(record)
+	record["route"] = [_record_location(record), _record_location(record)]
+	if next_member_count <= 0:
+		record["state"] = "defeated"
+		record["objective_id"] = "defeated"
+		record["objective_state"] = "defeated"
+		record["arrival_state"] = "stopped"
+		return
+	record["state"] = "post_battle"
+	record["objective_id"] = "post_battle"
+	record["objective_state"] = "interrupted"
+	record["arrival_state"] = "idle"
+
+
+func _battle_profile_for_squad(battle_result: Dictionary, squad_id: String) -> Dictionary:
+	var profile = _value_for_squad(battle_result.get("combat_profile", {}), squad_id, {})
+	return profile.duplicate(true) if profile is Dictionary else {}
+
+
+func _remaining_member_power(profile: Dictionary, battle_result: Dictionary, squad_id: String, next_member_count: int) -> float:
+	var remaining_power := maxf(float(profile.get("base_power", 0.0)) - _member_casualty_power(battle_result, squad_id), 0.0)
+	if next_member_count > 0 and remaining_power <= 0.0:
+		return float(next_member_count)
+	return remaining_power
+
+
+func _member_casualty_power(battle_result: Dictionary, squad_id: String) -> float:
+	var total := 0.0
+	var casualties = _value_for_squad(battle_result.get("member_casualties", {}), squad_id, [])
+	if not (casualties is Array):
+		return total
+	for casualty in casualties:
+		if casualty is Dictionary:
+			total += maxf(float(casualty.get("power_before", 0.0)), 0.0)
+	return total
+
+
+func _combat_capable_member_count(squad_record: Dictionary) -> int:
+	var count := 0
+	for member_record in _resolve_squad_member_records(squad_record):
+		if _member_record_can_fight(member_record):
+			count += 1
+	return count
+
+
+func _member_record_can_fight(member_record: Dictionary) -> bool:
+	if int(member_record.get("life_state", LIFE_STATE_ALIVE)) != LIFE_STATE_ALIVE:
+		return false
+	var max_hp := float(member_record.get("max_hp", 0.0))
+	if max_hp > 0.0 and float(member_record.get("hp", max_hp)) <= 0.0:
+		return false
+	var max_blood := float(member_record.get("max_blood", 0.0))
+	if max_blood > 0.0 and float(member_record.get("blood", max_blood)) <= 0.0:
+		return false
+	return true
+
+
+func _value_for_squad(source, squad_id: String, default_value):
+	if source is Dictionary:
+		return source.get(squad_id, default_value)
+	return default_value
+
+
+func _decrement_recent_pair_cooldowns(recent_pair_cooldowns: Dictionary) -> bool:
+	var changed := false
+	for pair_key in recent_pair_cooldowns.keys():
+		var next_ticks := int(recent_pair_cooldowns.get(pair_key, 0)) - 1
+		if next_ticks <= 0:
+			recent_pair_cooldowns.erase(pair_key)
+		else:
+			recent_pair_cooldowns[pair_key] = next_ticks
+		changed = true
+	return changed
+
+
 func _detect_squad_encounters() -> void:
 	if _world_squad_state_component == null or not _world_squad_state_component.has_method("apply_state"):
 		return
@@ -446,6 +853,7 @@ func _detect_squad_encounters() -> void:
 	var encounter_state := get_world_encounter_state()
 	var encounters_by_id = _dictionary_from_state(encounter_state, "encounters_by_id")
 	var active_pair_keys = _dictionary_from_state(encounter_state, "active_pair_keys")
+	var recent_pair_cooldowns = _dictionary_from_state(encounter_state, "recent_pair_cooldowns")
 	var encounter_log := _encounter_log_from_state(encounter_state)
 	var encounter_range := maxf(float(encounter_state.get("encounter_range", DEFAULT_ENCOUNTER_RANGE)), 0.0)
 	if encounter_range <= 0.0:
@@ -496,6 +904,8 @@ func _detect_squad_encounters() -> void:
 						if _mark_duplicate_encounter_suppressed(pair_key, encounters_by_id, active_pair_keys, encounter_log):
 							encounters_changed = true
 						continue
+					if int(recent_pair_cooldowns.get(pair_key, 0)) > 0:
+						continue
 					if not active_squads.has(other_id):
 						continue
 					var other_record_value = active_squads[other_id]
@@ -530,6 +940,7 @@ func _detect_squad_encounters() -> void:
 	if encounters_changed:
 		encounter_state["encounters_by_id"] = encounters_by_id
 		encounter_state["active_pair_keys"] = active_pair_keys
+		encounter_state["recent_pair_cooldowns"] = recent_pair_cooldowns
 		encounter_state["next_encounter_id"] = next_encounter_id
 		encounter_state["encounter_range"] = encounter_range
 		encounter_state["spatial_bin_size"] = spatial_bin_size
@@ -706,6 +1117,7 @@ func _encounter_record(encounter_id: String, pair_key: String, squad_a_id: Strin
 		"defender_squad_id": str(decision.get("defender_squad_id", "")),
 		"reason": str(decision.get("reason", "")),
 		"debug_only": bool(decision.get("debug_only", false)),
+		"is_debug_forced": bool(decision.get("debug_only", false)),
 		"created_tick": _current_tick_count(),
 		"location": squad_a_location.lerp(squad_b_location, 0.5),
 		"distance_squared": distance_squared,
@@ -747,10 +1159,11 @@ func _encounter_log_from_state(state: Dictionary) -> Array[Dictionary]:
 
 
 func _append_encounter_log(encounter_log: Array[Dictionary], status: String, encounter_id: String, pair_key: String, message: String) -> void:
+	var action := "encounter_resolution" if status == "resolving" or status == "resolved" else "encounter_detection"
 	encounter_log.append({
 		"log_id": encounter_log.size() + 1,
 		"status": status,
-		"action": "encounter_detection",
+		"action": action,
 		"encounter_id": encounter_id,
 		"pair_key": pair_key,
 		"message": message,
@@ -788,7 +1201,7 @@ func _append_command_log(command_log: Array[Dictionary], command: Dictionary, st
 
 func _string_array(value) -> Array[String]:
 	var result: Array[String] = []
-	if not (value is Array):
+	if not (value is Array) and not (value is PackedStringArray):
 		return result
 	for item in value:
 		var text := str(item).strip_edges()
@@ -899,6 +1312,16 @@ func _squad_id_for_template(template: Resource, index: int) -> String:
 	return "demo_squad:%s" % template_id
 
 
+func _member_ids_for_squad_template(squad_id: String, template: Resource, member_count: int) -> Array[String]:
+	var result: Array[String] = []
+	var template_id := _resource_id(template)
+	if template_id.is_empty():
+		template_id = squad_id.replace("demo_squad:", "")
+	for member_index in range(maxi(0, member_count)):
+		result.append("demo_member:%s:%02d" % [template_id, member_index + 1])
+	return result
+
+
 func _template_faction_id(template: Resource) -> String:
 	if template != null and template.has_method("get_faction_id"):
 		return str(template.call("get_faction_id")).strip_edges()
@@ -924,6 +1347,27 @@ func _resource_float(resource: Resource, property_name: String, default_value: f
 		return default_value
 	var value = resource.get(property_name)
 	return default_value if value == null else float(value)
+
+
+func _resource_string(resource: Resource, property_name: String, default_value: String) -> String:
+	return str(resource.get(property_name)).strip_edges() if resource != null else default_value
+
+
+func _resource_string_array(resource: Resource, property_name: String) -> Array[String]:
+	if resource == null:
+		return []
+	return _string_array(resource.get(property_name))
+
+
+func _safe_node_name(value: String) -> String:
+	var result := ""
+	for index in range(value.length()):
+		var character := value.substr(index, 1)
+		if character.is_valid_identifier() or character.is_valid_int():
+			result += character
+		else:
+			result += "_"
+	return result if not result.is_empty() else "record"
 
 
 func _world_definition_id() -> String:

--- a/scripts/ecs/components/c_game_population_record.gd
+++ b/scripts/ecs/components/c_game_population_record.gd
@@ -18,6 +18,13 @@ class_name CGamePopulationRecord
 @export var traits: Dictionary = {}
 @export var personality: Dictionary = {}
 @export var life_state := 0
+@export var hp := 0.0
+@export var max_hp := 0.0
+@export var blood := 0.0
+@export var max_blood := 0.0
+@export var base_attack_damage := 0.0
+@export var base_dodge_chance := 0.0
+@export var base_block_chance := 0.0
 @export var realization_state := "ledger"
 @export var ledger_activity_state := "routine"
 @export var ledger_minutes_elapsed := 0
@@ -64,6 +71,13 @@ func apply_record(source: Dictionary) -> void:
 	traits = (source.get("traits", traits) as Dictionary).duplicate(true)
 	personality = (source.get("personality", personality) as Dictionary).duplicate(true)
 	life_state = int(source.get("life_state", life_state))
+	hp = float(source.get("hp", hp))
+	max_hp = float(source.get("max_hp", max_hp))
+	blood = float(source.get("blood", blood))
+	max_blood = float(source.get("max_blood", max_blood))
+	base_attack_damage = float(source.get("base_attack_damage", base_attack_damage))
+	base_dodge_chance = float(source.get("base_dodge_chance", base_dodge_chance))
+	base_block_chance = float(source.get("base_block_chance", base_block_chance))
 	realization_state = str(source.get("realization_state", realization_state))
 	ledger_activity_state = str(source.get("ledger_activity_state", ledger_activity_state))
 	ledger_minutes_elapsed = int(source.get("ledger_minutes_elapsed", ledger_minutes_elapsed))
@@ -111,6 +125,13 @@ func to_record() -> Dictionary:
 		"traits": traits.duplicate(true),
 		"personality": personality.duplicate(true),
 		"life_state": life_state,
+		"hp": hp,
+		"max_hp": max_hp,
+		"blood": blood,
+		"max_blood": max_blood,
+		"base_attack_damage": base_attack_damage,
+		"base_dodge_chance": base_dodge_chance,
+		"base_block_chance": base_block_chance,
 		"realization_state": realization_state,
 		"ledger_activity_state": ledger_activity_state,
 		"ledger_minutes_elapsed": ledger_minutes_elapsed,

--- a/scripts/ecs/components/c_game_world_encounter_state.gd
+++ b/scripts/ecs/components/c_game_world_encounter_state.gd
@@ -5,10 +5,13 @@ class_name CGameWorldEncounterState
 @export var state_id := "world_encounters"
 @export var encounters_by_id: Dictionary = {}
 @export var active_pair_keys: Dictionary = {}
+@export var recent_pair_cooldowns: Dictionary = {}
 @export var next_encounter_id := 1
 @export var encounter_range := 30.0
 @export var spatial_bin_size := 60.0
 @export var hostile_threshold := -50
+@export var default_resolution_ticks := 1
+@export var encounter_repeat_cooldown_ticks := 30
 @export var encounter_log: Array[Dictionary] = []
 
 
@@ -16,10 +19,13 @@ func apply_state(source: Dictionary) -> void:
 	state_id = str(source.get("state_id", state_id))
 	encounters_by_id = (source.get("encounters_by_id", encounters_by_id) as Dictionary).duplicate(true)
 	active_pair_keys = (source.get("active_pair_keys", active_pair_keys) as Dictionary).duplicate(true)
+	recent_pair_cooldowns = (source.get("recent_pair_cooldowns", recent_pair_cooldowns) as Dictionary).duplicate(true)
 	next_encounter_id = int(source.get("next_encounter_id", next_encounter_id))
 	encounter_range = float(source.get("encounter_range", encounter_range))
 	spatial_bin_size = float(source.get("spatial_bin_size", spatial_bin_size))
 	hostile_threshold = int(source.get("hostile_threshold", hostile_threshold))
+	default_resolution_ticks = int(source.get("default_resolution_ticks", default_resolution_ticks))
+	encounter_repeat_cooldown_ticks = int(source.get("encounter_repeat_cooldown_ticks", encounter_repeat_cooldown_ticks))
 	encounter_log = _dictionary_array(source.get("encounter_log", encounter_log))
 
 
@@ -28,10 +34,13 @@ func to_state() -> Dictionary:
 		"state_id": state_id,
 		"encounters_by_id": encounters_by_id.duplicate(true),
 		"active_pair_keys": active_pair_keys.duplicate(true),
+		"recent_pair_cooldowns": recent_pair_cooldowns.duplicate(true),
 		"next_encounter_id": next_encounter_id,
 		"encounter_range": encounter_range,
 		"spatial_bin_size": spatial_bin_size,
 		"hostile_threshold": hostile_threshold,
+		"default_resolution_ticks": default_resolution_ticks,
+		"encounter_repeat_cooldown_ticks": encounter_repeat_cooldown_ticks,
 		"encounter_log": encounter_log.duplicate(true),
 	}
 

--- a/scripts/sim/battle/battle_sim.gd
+++ b/scripts/sim/battle/battle_sim.gd
@@ -1,0 +1,497 @@
+extends RefCounted
+
+class_name BattleSim
+
+const DEFAULT_ROUND_COUNT := 3
+const MIN_POWER := 0.001
+const MEMBER_POWER_EXPONENT := 1.35
+
+const LIFE_STATE_ALIVE := 0
+const LIFE_STATE_ASLEEP := 1
+const LIFE_STATE_UNCONSCIOUS := 2
+const LIFE_STATE_DEAD := 3
+const LIFE_STATE_RECOVERY_COMA := 4
+const LIFE_STATE_DYING := 5
+
+const COMBAT_STANCE_AGGRESSIVE := 0
+const COMBAT_STANCE_DEFENSIVE := 1
+const COMBAT_STANCE_PASSIVE := 2
+
+const ATTRIBUTE_STRENGTH := "attribute.strength"
+const ATTRIBUTE_PERCEPTION := "attribute.perception"
+const ATTRIBUTE_DEXTERITY := "attribute.dexterity"
+const ATTRIBUTE_TOUGHNESS := "attribute.toughness"
+const ATTRIBUTE_ENDURANCE := "attribute.endurance"
+const COMBAT_SWORDS_ONE_HANDED := "combat.swords_one_handed"
+const COMBAT_AXES_ONE_HANDED := "combat.axes_one_handed"
+const COMBAT_DAGGERS := "combat.daggers"
+const COMBAT_UNARMED := "combat.unarmed"
+const COMBAT_SHIELDS := "combat.shields"
+
+
+static func resolve_encounter(encounter_record: Dictionary, squad_a_record: Dictionary, squad_b_record: Dictionary, config: Dictionary) -> Dictionary:
+	var squad_a_id := str(squad_a_record.get("squad_id", _squad_id_from_encounter(encounter_record, 0))).strip_edges()
+	var squad_b_id := str(squad_b_record.get("squad_id", _squad_id_from_encounter(encounter_record, 1))).strip_edges()
+	var rounds := maxi(1, int(config.get("rounds", DEFAULT_ROUND_COUNT)))
+	var rng := RandomNumberGenerator.new()
+	rng.seed = _seed_from_config(encounter_record, config)
+	var profile_a := _combat_profile(squad_a_record)
+	var profile_b := _combat_profile(squad_b_record)
+	var power_a := _effective_power(profile_a, squad_a_record, encounter_record, rng)
+	var power_b := _effective_power(profile_b, squad_b_record, encounter_record, rng)
+	profile_a["effective_power"] = power_a
+	profile_b["effective_power"] = power_b
+	var total_power := maxf(power_a + power_b, MIN_POWER)
+	var outcome := _outcome(power_a, power_b)
+	var winner_id := ""
+	var loser_id := ""
+	if outcome == "squad_a_won":
+		winner_id = squad_a_id
+		loser_id = squad_b_id
+	elif outcome == "squad_b_won":
+		winner_id = squad_b_id
+		loser_id = squad_a_id
+	var casualty_count_a := _casualty_count_for(profile_a, squad_a_record, power_b / total_power, outcome == "squad_b_won", outcome == "draw", rng)
+	var casualty_count_b := _casualty_count_for(profile_b, squad_b_record, power_a / total_power, outcome == "squad_a_won", outcome == "draw", rng)
+	var member_casualties_a := _member_casualties_for(profile_a, casualty_count_a, outcome == "squad_b_won", rng)
+	var member_casualties_b := _member_casualties_for(profile_b, casualty_count_b, outcome == "squad_a_won", rng)
+	var casualties_a := member_casualties_a.size() if _profile_uses_members(profile_a) else casualty_count_a
+	var casualties_b := member_casualties_b.size() if _profile_uses_members(profile_b) else casualty_count_b
+	var morale_delta_a := _morale_delta(outcome, "squad_a_won", casualties_a, squad_a_record, profile_a)
+	var morale_delta_b := _morale_delta(outcome, "squad_b_won", casualties_b, squad_b_record, profile_b)
+	var supplies_delta_a := _supplies_delta(casualties_a, rounds, squad_a_record, profile_a)
+	var supplies_delta_b := _supplies_delta(casualties_b, rounds, squad_b_record, profile_b)
+	var beats := _combat_beats(profile_a, profile_b, power_a, power_b, rounds, int(config.get("current_tick", 0)), rng)
+	return {
+		"outcome": outcome,
+		"winner_squad_id": winner_id,
+		"loser_squad_id": loser_id,
+		"rounds": rounds,
+		"casualties": {
+			squad_a_id: casualties_a,
+			squad_b_id: casualties_b,
+		},
+		"member_casualties": {
+			squad_a_id: member_casualties_a,
+			squad_b_id: member_casualties_b,
+		},
+		"morale_delta": {
+			squad_a_id: morale_delta_a,
+			squad_b_id: morale_delta_b,
+		},
+		"supplies_delta": {
+			squad_a_id: supplies_delta_a,
+			squad_b_id: supplies_delta_b,
+		},
+		"beats": beats,
+		"summary": _summary(outcome, squad_a_id, squad_b_id, winner_id, loser_id, rounds),
+		"final_outcome_reason": _outcome_reason(power_a, power_b, profile_a, profile_b),
+		"power": {
+			squad_a_id: power_a,
+			squad_b_id: power_b,
+		},
+		"combat_profile": {
+			squad_a_id: profile_a,
+			squad_b_id: profile_b,
+		},
+	}
+
+
+static func _combat_profile(record: Dictionary) -> Dictionary:
+	var squad_id := str(record.get("squad_id", "")).strip_edges()
+	var member_records := _dictionary_array(record.get("member_records", []))
+	var member_profiles: Array[Dictionary] = []
+	var participants: Array[Dictionary] = []
+	for member_record in member_records:
+		var member_profile := _member_profile(member_record, squad_id)
+		if str(member_profile.get("member_id", "")).is_empty():
+			continue
+		member_profiles.append(member_profile)
+		if bool(member_profile.get("can_participate", false)):
+			participants.append(member_profile)
+	if not member_profiles.is_empty():
+		return _member_combat_profile(record, member_profiles, participants)
+	return _fallback_combat_profile(record)
+
+
+static func _member_combat_profile(record: Dictionary, member_profiles: Array[Dictionary], participants: Array[Dictionary]) -> Dictionary:
+	var base_power := 0.0
+	var offense := 0.0
+	var defense := 0.0
+	for member_profile in participants:
+		base_power += float(member_profile.get("power", 0.0))
+		offense += float(member_profile.get("offense", 0.0))
+		defense += float(member_profile.get("defense", 0.0))
+	return {
+		"squad_id": str(record.get("squad_id", "")).strip_edges(),
+		"source": "members",
+		"member_records_used": true,
+		"member_records_are_canonical": bool(record.get("member_records_are_canonical", false)),
+		"member_record_count": member_profiles.size(),
+		"member_count": member_profiles.size(),
+		"participant_count": participants.size(),
+		"excluded_member_count": maxi(0, member_profiles.size() - participants.size()),
+		"base_power": base_power,
+		"average_offense": offense / maxf(float(participants.size()), 1.0),
+		"average_defense": defense / maxf(float(participants.size()), 1.0),
+		"member_profiles": member_profiles,
+		"participants": participants,
+	}
+
+
+static func _fallback_combat_profile(record: Dictionary) -> Dictionary:
+	var members := maxi(0, int(record.get("member_count", 0)))
+	return {
+		"squad_id": str(record.get("squad_id", "")).strip_edges(),
+		"source": "squad_fallback",
+		"member_records_used": false,
+		"member_records_are_canonical": false,
+		"member_record_count": 0,
+		"member_count": members,
+		"participant_count": members,
+		"excluded_member_count": 0,
+		"base_power": _fallback_base_power(record),
+		"average_offense": 0.0,
+		"average_defense": 0.0,
+		"member_profiles": [],
+		"participants": [],
+	}
+
+
+static func _member_profile(record: Dictionary, squad_id: String) -> Dictionary:
+	var skill_levels: Dictionary = record.get("skill_levels", {}) if record.get("skill_levels", {}) is Dictionary else {}
+	var best_weapon_skill := maxf(
+		maxf(_skill_level(skill_levels, COMBAT_SWORDS_ONE_HANDED), _skill_level(skill_levels, COMBAT_AXES_ONE_HANDED)),
+		maxf(_skill_level(skill_levels, COMBAT_DAGGERS), _skill_level(skill_levels, COMBAT_UNARMED))
+	)
+	var shields := _skill_level(skill_levels, COMBAT_SHIELDS)
+	var strength := _skill_level(skill_levels, ATTRIBUTE_STRENGTH)
+	var perception := _skill_level(skill_levels, ATTRIBUTE_PERCEPTION)
+	var dexterity := _skill_level(skill_levels, ATTRIBUTE_DEXTERITY)
+	var toughness := _skill_level(skill_levels, ATTRIBUTE_TOUGHNESS)
+	var endurance := _skill_level(skill_levels, ATTRIBUTE_ENDURANCE)
+	var offense := 1.0 + best_weapon_skill * 1.2 + strength * 0.7 + dexterity * 0.55 + perception * 0.35
+	var defense := 1.0 + toughness * 0.75 + endurance * 0.55 + dexterity * 0.35 + shields * 0.45
+	offense += maxf(float(record.get("base_attack_damage", 0.0)), 0.0) * 0.08
+	defense *= _chance_factor(record.get("base_dodge_chance", 0.0), 0.35)
+	defense *= _chance_factor(record.get("base_block_chance", 0.0), 0.45)
+	var life_state := _life_state(record.get("life_state", LIFE_STATE_ALIVE))
+	var stance := _combat_stance(record.get("combat_stance", COMBAT_STANCE_DEFENSIVE))
+	var initiative_factor := 1.0
+	var survival_factor := 1.0
+	match stance:
+		COMBAT_STANCE_AGGRESSIVE:
+			offense *= 1.08
+			defense *= 0.96
+			initiative_factor = 1.08
+		COMBAT_STANCE_DEFENSIVE:
+			offense *= 0.96
+			defense *= 1.08
+			survival_factor = 1.1
+		COMBAT_STANCE_PASSIVE:
+			offense *= 0.65
+			initiative_factor = 0.65
+	var condition := _condition_factor(record)
+	var can_participate := _life_state_can_participate(life_state) and _vitals_allow_participation(record)
+	var raw_power := (offense * 0.58 + defense * 0.42) * condition * initiative_factor
+	var power := pow(maxf(raw_power, 1.0), MEMBER_POWER_EXPONENT) if can_participate else 0.0
+	return {
+		"member_id": _member_id(record),
+		"actor_id": str(record.get("actor_id", "")).strip_edges(),
+		"stable_id": str(record.get("stable_id", "")).strip_edges(),
+		"member_name": str(record.get("member_name", record.get("actor_id", ""))).strip_edges(),
+		"squad_id": squad_id,
+		"faction_id": str(record.get("faction_id", "")).strip_edges(),
+		"life_state": life_state,
+		"combat_stance": stance,
+		"can_participate": can_participate,
+		"condition": condition,
+		"best_weapon_skill": best_weapon_skill,
+		"shield_skill": shields,
+		"offense": offense,
+		"defense": defense,
+		"survival_score": maxf(defense * condition * survival_factor, 0.1),
+		"power": power,
+	}
+
+
+static func _effective_power(profile: Dictionary, record: Dictionary, encounter_record: Dictionary, rng: RandomNumberGenerator) -> float:
+	var base_power := maxf(float(profile.get("base_power", 0.0)), 0.0)
+	if base_power <= 0.0:
+		return 0.0
+	var morale_factor := _scale_factor(float(record.get("morale", 1.0)), 0.25, 1.25)
+	var supplies_factor := _scale_factor(float(record.get("supplies", 1.0)), 0.25, 1.1)
+	var objective_modifier := _objective_modifier(record, encounter_record)
+	var variation := rng.randf_range(0.92, 1.08)
+	return base_power * morale_factor * supplies_factor * objective_modifier * variation
+
+
+static func _fallback_base_power(record: Dictionary) -> float:
+	var member_count := maxf(float(record.get("member_count", 0)), 0.0)
+	if member_count <= 0.0:
+		return 0.0
+	var strength := maxf(float(record.get("strength", 0.0)), member_count)
+	var strength_factor := maxf(strength / member_count, 1.0)
+	return member_count * strength_factor
+
+
+static func _scale_factor(value: float, minimum: float, maximum: float) -> float:
+	var normalized := value if value <= 1.5 else value / 100.0
+	return clampf(normalized, minimum, maximum)
+
+
+static func _objective_modifier(record: Dictionary, encounter_record: Dictionary) -> float:
+	var squad_id := str(record.get("squad_id", ""))
+	var modifier := 1.0
+	if str(encounter_record.get("initiator_squad_id", "")) == squad_id:
+		modifier += 0.08
+	match str(record.get("objective_id", "")):
+		"raid", "patrol_for_raid_targets", "force_encounter_debug", "debug_force_encounter":
+			modifier += 0.04
+	return modifier
+
+
+static func _outcome(power_a: float, power_b: float) -> String:
+	var total_power := maxf(power_a + power_b, MIN_POWER)
+	var margin := absf(power_a - power_b) / total_power
+	if margin < 0.08:
+		return "draw"
+	return "squad_a_won" if power_a > power_b else "squad_b_won"
+
+
+static func _casualty_count_for(profile: Dictionary, record: Dictionary, opposing_power_share: float, lost: bool, draw: bool, rng: RandomNumberGenerator) -> int:
+	var members := maxi(0, int(profile.get("participant_count", record.get("member_count", 0))))
+	if members <= 0:
+		return 0
+	var base_rate := 0.16 + opposing_power_share * 0.28
+	if lost:
+		base_rate += 0.28
+	if draw:
+		base_rate += 0.08
+	var casualty_rate := clampf(base_rate + rng.randf_range(-0.08, 0.08), 0.0, 1.0)
+	return clampi(int(round(float(members) * casualty_rate)), 0, members)
+
+
+static func _member_casualties_for(profile: Dictionary, casualty_count: int, lost: bool, rng: RandomNumberGenerator) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	if not _profile_uses_members(profile):
+		return result
+	var participants := _dictionary_array(profile.get("participants", []))
+	if participants.is_empty() or casualty_count <= 0:
+		return result
+	var candidates: Array[Dictionary] = []
+	for member_profile in participants:
+		var survival_score := maxf(float(member_profile.get("survival_score", 1.0)), 0.1)
+		var risk := rng.randf_range(0.0, 1.0) + 1.0 / survival_score
+		if lost:
+			risk += 0.15
+		candidates.append({"member": member_profile, "risk": risk})
+	candidates.sort_custom(func(first: Dictionary, second: Dictionary) -> bool: return float(first.get("risk", 0.0)) > float(second.get("risk", 0.0)))
+	for index in range(mini(casualty_count, candidates.size())):
+		var member: Dictionary = candidates[index].get("member", {})
+		result.append({
+			"member_id": str(member.get("member_id", "")),
+			"actor_id": str(member.get("actor_id", "")),
+			"stable_id": str(member.get("stable_id", "")),
+			"member_name": str(member.get("member_name", "")),
+			"squad_id": str(profile.get("squad_id", "")),
+			"casualty_state": "dying",
+			"life_state": LIFE_STATE_DYING,
+			"fatal": false,
+			"power_before": float(member.get("power", 0.0)),
+		})
+	return result
+
+
+static func _morale_delta(outcome: String, winning_outcome: String, casualties: int, record: Dictionary, profile: Dictionary) -> float:
+	var members := maxf(float(profile.get("participant_count", record.get("member_count", 0))), 1.0)
+	var casualty_pressure := float(casualties) / members
+	if outcome == "draw":
+		return -0.12 - casualty_pressure * 0.25
+	if outcome == winning_outcome:
+		return 0.08 - casualty_pressure * 0.18
+	return -0.22 - casualty_pressure * 0.35
+
+
+static func _supplies_delta(casualties: int, rounds: int, record: Dictionary, profile: Dictionary) -> float:
+	var members := maxf(float(profile.get("participant_count", record.get("member_count", 0))), 0.0)
+	return -minf(float(rounds) * 0.35 + members * 0.08 + float(casualties) * 0.15, float(record.get("supplies", 0.0)))
+
+
+static func _combat_beats(profile_a: Dictionary, profile_b: Dictionary, power_a: float, power_b: float, rounds: int, current_tick: int, rng: RandomNumberGenerator) -> Array[Dictionary]:
+	var beats: Array[Dictionary] = []
+	var squad_a_id := str(profile_a.get("squad_id", ""))
+	var squad_b_id := str(profile_b.get("squad_id", ""))
+	for round_index in range(1, rounds + 1):
+		var a_advantage := power_a - power_b + rng.randf_range(-4.0, 4.0)
+		var attacker_profile := profile_a if a_advantage >= 0.0 else profile_b
+		var defender_profile := profile_b if attacker_profile == profile_a else profile_a
+		var attacker_squad_id := str(attacker_profile.get("squad_id", ""))
+		var defender_squad_id := squad_b_id if attacker_squad_id == squad_a_id else squad_a_id
+		if not str(defender_profile.get("squad_id", "")).is_empty():
+			defender_squad_id = str(defender_profile.get("squad_id", ""))
+		var attacker_member := _pick_beat_member(attacker_profile, rng)
+		var defender_member := _pick_beat_member(defender_profile, rng)
+		var attacker_id := str(attacker_member.get("member_id", attacker_squad_id))
+		var defender_id := str(defender_member.get("member_id", defender_squad_id))
+		var attacker_name := str(attacker_member.get("member_name", attacker_squad_id))
+		var defender_name := str(defender_member.get("member_name", defender_squad_id))
+		var damage := maxf(absf(a_advantage) / float(rounds), 0.1)
+		beats.append({
+			"tick": current_tick,
+			"round": round_index,
+			"attacker_squad_id": attacker_squad_id,
+			"defender_squad_id": defender_squad_id,
+			"attacker_id": attacker_id,
+			"defender_id": defender_id,
+			"attacker_name": attacker_name,
+			"defender_name": defender_name,
+			"action": "attack",
+			"result": "hit",
+			"damage": damage,
+			"importance": "high" if round_index == rounds else "normal",
+			"summary": _beat_summary(attacker_name, attacker_squad_id, defender_name, defender_squad_id, damage),
+		})
+	return beats
+
+
+static func _pick_beat_member(profile: Dictionary, rng: RandomNumberGenerator) -> Dictionary:
+	var participants := _dictionary_array(profile.get("participants", []))
+	if participants.is_empty():
+		return {}
+	var total_power := 0.0
+	for member_profile in participants:
+		total_power += maxf(float(member_profile.get("power", 0.0)), 0.0)
+	if total_power <= 0.0:
+		return participants[rng.randi_range(0, participants.size() - 1)]
+	var roll := rng.randf_range(0.0, total_power)
+	var cursor := 0.0
+	for member_profile in participants:
+		cursor += maxf(float(member_profile.get("power", 0.0)), 0.0)
+		if roll <= cursor:
+			return member_profile
+	return participants[participants.size() - 1]
+
+
+static func _summary(outcome: String, squad_a_id: String, squad_b_id: String, winner_id: String, loser_id: String, rounds: int) -> String:
+	if outcome == "draw":
+		return "%s and %s fought to a draw after %d rounds." % [squad_a_id, squad_b_id, rounds]
+	return "%s defeated %s after %d rounds." % [winner_id, loser_id, rounds]
+
+
+static func _beat_summary(attacker_name: String, attacker_squad_id: String, defender_name: String, defender_squad_id: String, damage: float) -> String:
+	var attacker_label := attacker_name if not attacker_name.is_empty() else attacker_squad_id
+	var defender_label := defender_name if not defender_name.is_empty() else defender_squad_id
+	return "%s pressured %s for %.1f combat damage." % [attacker_label, defender_label, damage]
+
+
+static func _outcome_reason(power_a: float, power_b: float, profile_a: Dictionary, profile_b: Dictionary) -> String:
+	var total_power := maxf(power_a + power_b, MIN_POWER)
+	var margin := absf(power_a - power_b) / total_power
+	if margin < 0.08:
+		return "Combat power was too close for a decisive result."
+	if _profile_uses_members(profile_a) or _profile_uses_members(profile_b):
+		return "Resolved from member combat profiles; higher effective member power decided the battle."
+	return "Higher effective squad power decided the battle."
+
+
+static func _profile_uses_members(profile: Dictionary) -> bool:
+	return str(profile.get("source", "")) == "members"
+
+
+static func _dictionary_array(value) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	if not (value is Array):
+		return result
+	for entry in value:
+		if entry is Dictionary:
+			result.append(entry.duplicate(true))
+	return result
+
+
+static func _member_id(record: Dictionary) -> String:
+	for key in ["actor_id", "stable_id", "member_id"]:
+		var value := str(record.get(key, "")).strip_edges()
+		if not value.is_empty():
+			return value
+	return ""
+
+
+static func _skill_level(skill_levels: Dictionary, skill_id: String) -> float:
+	return maxf(float(skill_levels.get(skill_id, 1.0)), 0.0)
+
+
+static func _condition_factor(record: Dictionary) -> float:
+	var condition := 1.0
+	var max_hp := float(record.get("max_hp", 0.0))
+	if max_hp > 0.0:
+		condition = minf(condition, clampf(float(record.get("hp", max_hp)) / max_hp, 0.0, 1.0))
+	var max_blood := float(record.get("max_blood", 0.0))
+	if max_blood > 0.0:
+		condition = minf(condition, clampf(float(record.get("blood", max_blood)) / max_blood, 0.0, 1.0))
+	return condition
+
+
+static func _vitals_allow_participation(record: Dictionary) -> bool:
+	var max_hp := float(record.get("max_hp", 0.0))
+	if max_hp > 0.0 and float(record.get("hp", max_hp)) <= 0.0:
+		return false
+	var max_blood := float(record.get("max_blood", 0.0))
+	if max_blood > 0.0 and float(record.get("blood", max_blood)) <= 0.0:
+		return false
+	return true
+
+
+static func _life_state_can_participate(life_state: int) -> bool:
+	return life_state == LIFE_STATE_ALIVE
+
+
+static func _life_state(value) -> int:
+	if value is String:
+		match str(value).strip_edges().to_upper():
+			"ALIVE":
+				return LIFE_STATE_ALIVE
+			"ASLEEP":
+				return LIFE_STATE_ASLEEP
+			"UNCONSCIOUS":
+				return LIFE_STATE_UNCONSCIOUS
+			"DEAD":
+				return LIFE_STATE_DEAD
+			"RECOVERY_COMA":
+				return LIFE_STATE_RECOVERY_COMA
+			"DYING":
+				return LIFE_STATE_DYING
+	return int(value)
+
+
+static func _combat_stance(value) -> int:
+	if value is String:
+		match str(value).strip_edges().to_upper():
+			"AGGRESSIVE":
+				return COMBAT_STANCE_AGGRESSIVE
+			"DEFENSIVE":
+				return COMBAT_STANCE_DEFENSIVE
+			"PASSIVE":
+				return COMBAT_STANCE_PASSIVE
+	return int(value)
+
+
+static func _chance_factor(value, scale: float) -> float:
+	var chance := maxf(float(value), 0.0)
+	if chance > 1.0:
+		chance /= 100.0
+	return 1.0 + clampf(chance, 0.0, 1.0) * scale
+
+
+static func _squad_id_from_encounter(encounter_record: Dictionary, index: int) -> String:
+	var squad_ids = encounter_record.get("squad_ids", [])
+	if squad_ids is Array and index >= 0 and index < squad_ids.size():
+		return str(squad_ids[index])
+	return ""
+
+
+static func _seed_from_config(encounter_record: Dictionary, config: Dictionary) -> int:
+	var seed_text := str(config.get("seed", "")).strip_edges()
+	if seed_text.is_empty():
+		seed_text = "%s|%s" % [str(encounter_record.get("encounter_id", "")), str(encounter_record.get("created_tick", 0))]
+	return abs(hash(seed_text))

--- a/scripts/sim/battle/battle_sim.gd.uid
+++ b/scripts/sim/battle/battle_sim.gd.uid
@@ -1,0 +1,1 @@
+uid://dhb4265kt1jvd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic multi-round battle simulator with per-round "beat" narratives and outcome summaries.
  * Tick-based encounter lifecycle that moves encounters from engaged→resolving→resolved and enforces repeat cooldowns.
  * Battle outcomes update squad stats (member counts, strength, morale, supplies) and record resolution metadata including debug-forced flags.
  * Demo population records are auto-created/refreshed and now persist member health and baseline combat stats.
  * Encounter detection/logging now persists pair cooldowns and clearer detection/resolution actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->