### PR TITLE
Add fighter pairing engagement groups

### DIFF
--- a/architecture/GameAI/combat_beats.md
+++ b/architecture/GameAI/combat_beats.md
@@ -77,17 +77,48 @@ Optional member-level fields:
 
 Missing optional member fields mean BattleSim used squad-level fallback data for that side. Projection must handle that without inventing member truth.
 
-## Engagement Group Fallback
+## #88 Engagement Groups
 
-#87 does not solve fighter pairing or engagement grouping.
+BattleSim emits `battle_result["engagement_groups"]` as data-first presentation grouping. Actors do not choose targets and projected actors do not scan for enemies.
 
-Until #88 creates real engagement groups, BattleSim emits one deterministic fallback group per encounter:
+Engagement group records use this shape:
 
-```gdscript
-engagement_group_id = "%s:group:main" % encounter_id
+```text
+EngagementGroup
+  engagement_group_id
+  encounter_id
+  group_index
+  group_role
+  strategy
+  max_group_size
+  side_a_squad_id
+  side_b_squad_id
+  side_a_primary_id
+  side_b_primary_id
+  side_a_member_ids
+  side_b_member_ids
+  support_member_ids
+  reserve_member_ids
 ```
 
-#88 replaces this fallback with real data-first pairings and engagement groups. Projection and scheduler code can still rely on every new beat having a stable group key now.
+`side_a_member_ids` and `side_b_member_ids` are the side-owned assigned members for the group. `support_member_ids` and `reserve_member_ids` classify non-primary members inside those side assignments.
+
+Group IDs are stable per encounter:
+
+```gdscript
+engagement_group_id = "%s:group:%03d" % [encounter_id, group_index]
+```
+
+New beats reference an existing `engagement_group_id`. Member-level fights use deterministic groups. Squad-fallback fights still emit one fallback group and keep member IDs empty.
+
+Current grouping strategy:
+
+- Sort living participants deterministically by combat score, then stable member ID.
+- Create paired groups with one primary from each side when possible.
+- Keep group size bounded by `max_group_size = 4`.
+- Assign extras as support into existing groups while room remains.
+- Assign remaining extras into reserve groups.
+- Use O(N log N) sorting plus O(N) assignment, not all-vs-all matching.
 
 ## Known #87 Gaps
 
@@ -97,7 +128,7 @@ BattleSim does not yet populate these optional projection fields with meaningful
 - wound target
 - life-state result per beat
 - slot, position, or facing hints
-- real engagement group or fighter pairing assignments
+- tactical target selection beyond deterministic engagement groups
 
 Those fields remain optional until the relevant systems produce durable result data. Projection must not invent them as truth.
 

--- a/scripts/sim/battle/battle_sim.gd
+++ b/scripts/sim/battle/battle_sim.gd
@@ -5,6 +5,8 @@ class_name BattleSim
 const DEFAULT_ROUND_COUNT := 3
 const MIN_POWER := 0.001
 const MEMBER_POWER_EXPONENT := 1.35
+const MAX_ENGAGEMENT_GROUP_SIZE := 4
+const ENGAGEMENT_GROUP_STRATEGY := "deterministic_sorted_bounded"
 
 const LIFE_STATE_ALIVE := 0
 const LIFE_STATE_ASLEEP := 1
@@ -62,7 +64,8 @@ static func resolve_encounter(encounter_record: Dictionary, squad_a_record: Dict
 	var supplies_delta_a := _supplies_delta(casualties_a, rounds, squad_a_record, profile_a)
 	var supplies_delta_b := _supplies_delta(casualties_b, rounds, squad_b_record, profile_b)
 	var encounter_id := _combat_beat_encounter_id(encounter_record, config)
-	var beats := _combat_beats(profile_a, profile_b, power_a, power_b, rounds, int(config.get("current_tick", 0)), encounter_id, rng)
+	var engagement_groups := _engagement_groups(profile_a, profile_b, encounter_id, squad_a_id, squad_b_id)
+	var beats := _combat_beats(profile_a, profile_b, power_a, power_b, rounds, int(config.get("current_tick", 0)), encounter_id, engagement_groups, rng)
 	return {
 		"outcome": outcome,
 		"winner_squad_id": winner_id,
@@ -95,6 +98,8 @@ static func resolve_encounter(encounter_record: Dictionary, squad_a_record: Dict
 			squad_a_id: profile_a,
 			squad_b_id: profile_b,
 		},
+		"engagement_groups": engagement_groups,
+		"engagement_grouping": _engagement_grouping_summary(profile_a, profile_b, engagement_groups),
 	}
 
 
@@ -326,12 +331,36 @@ static func _supplies_delta(casualties: int, rounds: int, record: Dictionary, pr
 	return -minf(float(rounds) * 0.35 + members * 0.08 + float(casualties) * 0.15, float(record.get("supplies", 0.0)))
 
 
-static func _combat_beats(profile_a: Dictionary, profile_b: Dictionary, power_a: float, power_b: float, rounds: int, current_tick: int, encounter_id: String, rng: RandomNumberGenerator) -> Array[Dictionary]:
+static func _engagement_groups(profile_a: Dictionary, profile_b: Dictionary, encounter_id: String, squad_a_id: String, squad_b_id: String) -> Array[Dictionary]:
+	var groups: Array[Dictionary] = []
+	var group_encounter_id := encounter_id.strip_edges()
+	if group_encounter_id.is_empty():
+		group_encounter_id = "encounter:untracked"
+	var side_a_participants := _sorted_engagement_participants(profile_a)
+	var side_b_participants := _sorted_engagement_participants(profile_b)
+	if side_a_participants.is_empty() and side_b_participants.is_empty():
+		groups.append(_squad_fallback_engagement_group(group_encounter_id, squad_a_id, squad_b_id))
+		return groups
+	var paired_count := mini(side_a_participants.size(), side_b_participants.size())
+	for index in range(paired_count):
+		var group := _engagement_group_record(group_encounter_id, groups.size() + 1, squad_a_id, squad_b_id, "paired")
+		_add_group_member(group, "a", side_a_participants[index], false, false)
+		_add_group_member(group, "b", side_b_participants[index], false, false)
+		groups.append(group)
+	var next_a_index := _assign_support_members(groups, side_a_participants, paired_count, "a")
+	var next_b_index := _assign_support_members(groups, side_b_participants, paired_count, "b")
+	_append_reserve_groups(groups, side_a_participants, next_a_index, "a", group_encounter_id, squad_a_id, squad_b_id)
+	_append_reserve_groups(groups, side_b_participants, next_b_index, "b", group_encounter_id, squad_a_id, squad_b_id)
+	if groups.is_empty():
+		groups.append(_squad_fallback_engagement_group(group_encounter_id, squad_a_id, squad_b_id))
+	return groups
+
+
+static func _combat_beats(profile_a: Dictionary, profile_b: Dictionary, power_a: float, power_b: float, rounds: int, current_tick: int, encounter_id: String, engagement_groups: Array[Dictionary], rng: RandomNumberGenerator) -> Array[Dictionary]:
 	var beats: Array[Dictionary] = []
 	var beat_encounter_id := encounter_id.strip_edges()
 	if beat_encounter_id.is_empty():
 		beat_encounter_id = "encounter:untracked"
-	var engagement_group_id := _fallback_engagement_group_id(beat_encounter_id)
 	var squad_a_id := str(profile_a.get("squad_id", ""))
 	var squad_b_id := str(profile_b.get("squad_id", ""))
 	for round_index in range(1, rounds + 1):
@@ -343,8 +372,10 @@ static func _combat_beats(profile_a: Dictionary, profile_b: Dictionary, power_a:
 		var defender_squad_id := squad_b_id if attacker_squad_id == squad_a_id else squad_a_id
 		if not str(defender_profile.get("squad_id", "")).is_empty():
 			defender_squad_id = str(defender_profile.get("squad_id", ""))
-		var attacker_member := _pick_beat_member(attacker_profile, rng)
-		var defender_member := _pick_beat_member(defender_profile, rng)
+		var engagement_group := _pick_beat_group(engagement_groups, attacker_squad_id, defender_squad_id, round_index)
+		var engagement_group_id := str(engagement_group.get("engagement_group_id", _engagement_group_id(beat_encounter_id, 1))).strip_edges()
+		var attacker_member := _pick_beat_member_for_group(attacker_profile, engagement_group, attacker_squad_id, rng)
+		var defender_member := _pick_beat_member_for_group(defender_profile, engagement_group, defender_squad_id, rng)
 		var attacker_member_id := str(attacker_member.get("member_id", "")).strip_edges()
 		var defender_member_id := str(defender_member.get("member_id", "")).strip_edges()
 		var attacker_id := attacker_member_id if not attacker_member_id.is_empty() else attacker_squad_id
@@ -381,6 +412,192 @@ static func _combat_beats(profile_a: Dictionary, profile_b: Dictionary, power_a:
 	return beats
 
 
+static func _engagement_grouping_summary(profile_a: Dictionary, profile_b: Dictionary, engagement_groups: Array[Dictionary]) -> Dictionary:
+	var side_a_participants := _sorted_engagement_participants(profile_a)
+	var side_b_participants := _sorted_engagement_participants(profile_b)
+	return {
+		"strategy": ENGAGEMENT_GROUP_STRATEGY,
+		"complexity": "O(N log N) sort + O(N) assignment",
+		"max_group_size": MAX_ENGAGEMENT_GROUP_SIZE,
+		"group_count": engagement_groups.size(),
+		"side_a_participant_count": side_a_participants.size(),
+		"side_b_participant_count": side_b_participants.size(),
+		"excluded_member_count": int(profile_a.get("excluded_member_count", 0)) + int(profile_b.get("excluded_member_count", 0)),
+	}
+
+
+static func _sorted_engagement_participants(profile: Dictionary) -> Array[Dictionary]:
+	var participants := _dictionary_array(profile.get("participants", []))
+	participants.sort_custom(func(first: Dictionary, second: Dictionary) -> bool:
+		var first_score := _engagement_sort_score(first)
+		var second_score := _engagement_sort_score(second)
+		if not is_equal_approx(first_score, second_score):
+			return first_score > second_score
+		return _member_group_id(first) < _member_group_id(second)
+	)
+	return participants
+
+
+static func _engagement_sort_score(member_profile: Dictionary) -> float:
+	return float(member_profile.get("power", 0.0))
+
+
+static func _member_group_id(member_profile: Dictionary) -> String:
+	for key in ["member_id", "actor_id", "stable_id"]:
+		var value := str(member_profile.get(key, "")).strip_edges()
+		if not value.is_empty():
+			return value
+	return ""
+
+
+static func _squad_fallback_engagement_group(encounter_id: String, squad_a_id: String, squad_b_id: String) -> Dictionary:
+	var group := _engagement_group_record(encounter_id, 1, squad_a_id, squad_b_id, "squad_fallback")
+	group["side_a_primary_id"] = squad_a_id
+	group["side_b_primary_id"] = squad_b_id
+	group["uses_squad_fallback"] = true
+	return group
+
+
+static func _engagement_group_record(encounter_id: String, group_index: int, squad_a_id: String, squad_b_id: String, group_role: String) -> Dictionary:
+	return {
+		"engagement_group_id": _engagement_group_id(encounter_id, group_index),
+		"encounter_id": encounter_id,
+		"group_index": group_index,
+		"group_role": group_role,
+		"strategy": ENGAGEMENT_GROUP_STRATEGY,
+		"max_group_size": MAX_ENGAGEMENT_GROUP_SIZE,
+		"side_a_squad_id": squad_a_id,
+		"side_b_squad_id": squad_b_id,
+		"side_a_primary_id": "",
+		"side_b_primary_id": "",
+		"side_a_member_ids": [],
+		"side_b_member_ids": [],
+		"support_member_ids": [],
+		"reserve_member_ids": [],
+		"uses_squad_fallback": false,
+	}
+
+
+static func _engagement_group_id(encounter_id: String, group_index: int) -> String:
+	return "%s:group:%03d" % [encounter_id, group_index]
+
+
+static func _add_group_member(group: Dictionary, side: String, member_profile: Dictionary, support: bool, reserve: bool) -> void:
+	var member_id := _member_group_id(member_profile)
+	if member_id.is_empty():
+		return
+	var side_key := "side_a_member_ids" if side == "a" else "side_b_member_ids"
+	var primary_key := "side_a_primary_id" if side == "a" else "side_b_primary_id"
+	var side_member_ids := _string_array(group.get(side_key, []))
+	if not side_member_ids.has(member_id):
+		side_member_ids.append(member_id)
+	group[side_key] = side_member_ids
+	if str(group.get(primary_key, "")).strip_edges().is_empty():
+		group[primary_key] = member_id
+	if support:
+		_append_unique_string_field(group, "support_member_ids", member_id)
+	if reserve:
+		_append_unique_string_field(group, "reserve_member_ids", member_id)
+
+
+static func _assign_support_members(groups: Array[Dictionary], members: Array[Dictionary], start_index: int, side: String) -> int:
+	var member_index := start_index
+	var group_index := 0
+	while member_index < members.size() and group_index < groups.size():
+		var group := groups[group_index]
+		if _engagement_group_size(group) >= MAX_ENGAGEMENT_GROUP_SIZE:
+			group_index += 1
+			continue
+		_add_group_member(group, side, members[member_index], true, false)
+		groups[group_index] = group
+		member_index += 1
+	return member_index
+
+
+static func _append_reserve_groups(groups: Array[Dictionary], members: Array[Dictionary], start_index: int, side: String, encounter_id: String, squad_a_id: String, squad_b_id: String) -> void:
+	var member_index := start_index
+	while member_index < members.size():
+		var group := _engagement_group_record(encounter_id, groups.size() + 1, squad_a_id, squad_b_id, "reserve")
+		while member_index < members.size() and _engagement_group_size(group) < MAX_ENGAGEMENT_GROUP_SIZE:
+			_add_group_member(group, side, members[member_index], false, true)
+			member_index += 1
+		groups.append(group)
+
+
+static func _append_unique_string_field(group: Dictionary, field_name: String, value: String) -> void:
+	var values := _string_array(group.get(field_name, []))
+	if not values.has(value):
+		values.append(value)
+	group[field_name] = values
+
+
+static func _engagement_group_size(group: Dictionary) -> int:
+	return _string_array(group.get("side_a_member_ids", [])).size() + _string_array(group.get("side_b_member_ids", [])).size()
+
+
+static func _pick_beat_group(engagement_groups: Array[Dictionary], attacker_squad_id: String, defender_squad_id: String, round_index: int) -> Dictionary:
+	if engagement_groups.is_empty():
+		return {}
+	var matching_groups: Array[Dictionary] = []
+	for group in engagement_groups:
+		if _group_has_squad_members(group, attacker_squad_id) and _group_has_squad_members(group, defender_squad_id):
+			matching_groups.append(group)
+	if matching_groups.is_empty():
+		return engagement_groups[0]
+	return matching_groups[maxi(0, round_index - 1) % matching_groups.size()]
+
+
+static func _group_has_squad_members(group: Dictionary, squad_id: String) -> bool:
+	var trimmed_squad_id := squad_id.strip_edges()
+	if trimmed_squad_id.is_empty():
+		return false
+	if str(group.get("side_a_squad_id", "")).strip_edges() == trimmed_squad_id:
+		return not _string_array(group.get("side_a_member_ids", [])).is_empty() or str(group.get("side_a_primary_id", "")).strip_edges() == trimmed_squad_id
+	if str(group.get("side_b_squad_id", "")).strip_edges() == trimmed_squad_id:
+		return not _string_array(group.get("side_b_member_ids", [])).is_empty() or str(group.get("side_b_primary_id", "")).strip_edges() == trimmed_squad_id
+	return false
+
+
+static func _pick_beat_member_for_group(profile: Dictionary, engagement_group: Dictionary, squad_id: String, rng: RandomNumberGenerator) -> Dictionary:
+	var member_ids := _group_member_ids_for_squad(engagement_group, squad_id)
+	if member_ids.is_empty():
+		return _pick_beat_member(profile, rng)
+	return _pick_beat_member_by_ids(profile, member_ids, rng)
+
+
+static func _group_member_ids_for_squad(group: Dictionary, squad_id: String) -> Array[String]:
+	var trimmed_squad_id := squad_id.strip_edges()
+	if str(group.get("side_a_squad_id", "")).strip_edges() == trimmed_squad_id:
+		return _string_array(group.get("side_a_member_ids", []))
+	if str(group.get("side_b_squad_id", "")).strip_edges() == trimmed_squad_id:
+		return _string_array(group.get("side_b_member_ids", []))
+	return []
+
+
+static func _pick_beat_member_by_ids(profile: Dictionary, member_ids: Array[String], rng: RandomNumberGenerator) -> Dictionary:
+	var allowed_ids := {}
+	for member_id in member_ids:
+		allowed_ids[member_id] = true
+	var candidates: Array[Dictionary] = []
+	for member_profile in _dictionary_array(profile.get("participants", [])):
+		if allowed_ids.has(_member_group_id(member_profile)):
+			candidates.append(member_profile)
+	if candidates.is_empty():
+		return _pick_beat_member(profile, rng)
+	var total_power := 0.0
+	for member_profile in candidates:
+		total_power += maxf(float(member_profile.get("power", 0.0)), 0.0)
+	if total_power <= 0.0:
+		return candidates[rng.randi_range(0, candidates.size() - 1)]
+	var roll := rng.randf_range(0.0, total_power)
+	var cursor := 0.0
+	for member_profile in candidates:
+		cursor += maxf(float(member_profile.get("power", 0.0)), 0.0)
+		if roll <= cursor:
+			return member_profile
+	return candidates[candidates.size() - 1]
+
+
 static func _combat_beat_encounter_id(encounter_record: Dictionary, config: Dictionary) -> String:
 	var config_id := str(config.get("encounter_id", "")).strip_edges()
 	if not config_id.is_empty():
@@ -390,10 +607,6 @@ static func _combat_beat_encounter_id(encounter_record: Dictionary, config: Dict
 
 static func _combat_beat_id(encounter_id: String, beat_index: int) -> String:
 	return "%s:beat:%03d" % [encounter_id, beat_index]
-
-
-static func _fallback_engagement_group_id(encounter_id: String) -> String:
-	return "%s:group:main" % encounter_id
 
 
 static func _pick_beat_member(profile: Dictionary, rng: RandomNumberGenerator) -> Dictionary:
@@ -447,6 +660,17 @@ static func _dictionary_array(value) -> Array[Dictionary]:
 	for entry in value:
 		if entry is Dictionary:
 			result.append(entry.duplicate(true))
+	return result
+
+
+static func _string_array(value) -> Array[String]:
+	var result: Array[String] = []
+	if not (value is Array) and not (value is PackedStringArray):
+		return result
+	for entry in value:
+		var text := str(entry).strip_edges()
+		if not text.is_empty():
+			result.append(text)
 	return result
 
 

--- a/scripts/validation/validate_combat_beat_contract.gd
+++ b/scripts/validation/validate_combat_beat_contract.gd
@@ -63,20 +63,22 @@ func _validate_squad_fallback_beats() -> void:
 
 func _validate_beats(result: Dictionary, expected_count: int, expects_member_ids: bool, label: String) -> void:
 	var beats: Array = result.get("beats", []) if result.get("beats", []) is Array else []
+	var engagement_group_ids := _engagement_group_ids(result)
+	_expect(not engagement_group_ids.is_empty(), "%s BattleSim emits engagement groups" % label)
 	_expect(beats.size() == expected_count, "%s BattleSim emits expected beat count" % label)
 	for index in range(beats.size()):
 		var beat: Dictionary = beats[index] if beats[index] is Dictionary else {}
 		var beat_index := index + 1
-		_validate_required_beat_fields(beat, beat_index, label)
+		_validate_required_beat_fields(beat, beat_index, engagement_group_ids, label)
 		_validate_beat_member_fields(beat, expects_member_ids, label)
 
 
-func _validate_required_beat_fields(beat: Dictionary, beat_index: int, label: String) -> void:
+func _validate_required_beat_fields(beat: Dictionary, beat_index: int, engagement_group_ids: Dictionary, label: String) -> void:
 	var encounter_id := str(beat.get("encounter_id", "")).strip_edges()
 	_expect(not encounter_id.is_empty(), "%s beat has encounter_id" % label)
 	_expect(int(beat.get("beat_index", 0)) == beat_index, "%s beat_index is stable and ordered" % label)
 	_expect(str(beat.get("beat_id", "")) == "%s:beat:%03d" % [encounter_id, beat_index], "%s beat_id is stable" % label)
-	_expect(str(beat.get("engagement_group_id", "")) == "%s:group:main" % encounter_id, "%s beat has #87 fallback engagement group" % label)
+	_expect(engagement_group_ids.has(str(beat.get("engagement_group_id", ""))), "%s beat references an existing engagement group" % label)
 	_expect(int(beat.get("tick", -1)) == CURRENT_TICK, "%s beat keeps source tick" % label)
 	_expect(int(beat.get("presentation_tick", -1)) == CURRENT_TICK + beat_index - 1, "%s beat has stable presentation_tick" % label)
 	_expect(int(beat.get("round", 0)) > 0, "%s beat has round" % label)
@@ -89,6 +91,17 @@ func _validate_required_beat_fields(beat: Dictionary, beat_index: int, label: St
 	_expect(float(beat.get("damage", -1.0)) >= 0.0, "%s beat has damage" % label)
 	_expect(not str(beat.get("importance", "")).strip_edges().is_empty(), "%s beat has importance" % label)
 	_expect(not str(beat.get("summary", "")).strip_edges().is_empty(), "%s beat has summary" % label)
+
+
+func _engagement_group_ids(result: Dictionary) -> Dictionary:
+	var ids := {}
+	var groups: Array = result.get("engagement_groups", []) if result.get("engagement_groups", []) is Array else []
+	for group in groups:
+		if group is Dictionary:
+			var group_id := str((group as Dictionary).get("engagement_group_id", "")).strip_edges()
+			if not group_id.is_empty():
+				ids[group_id] = true
+	return ids
 
 
 func _validate_beat_member_fields(beat: Dictionary, expects_member_ids: bool, label: String) -> void:

--- a/scripts/validation/validate_combat_engagement_groups.gd
+++ b/scripts/validation/validate_combat_engagement_groups.gd
@@ -1,0 +1,308 @@
+extends SceneTree
+
+const BATTLE_SIM_SCRIPT := preload("res://scripts/sim/battle/battle_sim.gd")
+const CURRENT_TICK := 88
+const MAX_GROUP_SIZE := 4
+const LIFE_STATE_ALIVE := 0
+const LIFE_STATE_DEAD := 3
+
+var _failures: Array[String] = []
+
+
+func _initialize() -> void:
+	call_deferred("_run_validation")
+
+
+func _run_validation() -> void:
+	_validate_1v1_groups()
+	_validate_1v3_groups()
+	_validate_5v5_groups()
+	_validate_50v50_groups()
+	_validate_squad_fallback_groups()
+	_finish()
+
+
+func _validate_1v1_groups() -> void:
+	var result := _resolve_member_case("one_v_one", 1, 1)
+	_validate_group_contract(result, _member_ids("one_v_one.a", 1), _member_ids("one_v_one.b", 1), [], "1v1")
+	_expect(_groups(result).size() == 1, "1v1 creates one engagement group")
+
+
+func _validate_1v3_groups() -> void:
+	var result := _resolve_member_case("one_v_three", 1, 3)
+	_validate_group_contract(result, _member_ids("one_v_three.a", 1), _member_ids("one_v_three.b", 3), [], "1v3")
+	var groups := _groups(result)
+	_expect(groups.size() == 1, "1v3 creates one bounded group")
+	if groups.size() == 1 and groups[0] is Dictionary:
+		var group: Dictionary = groups[0]
+		_expect(_string_array(group.get("side_a_member_ids", [])).size() == 1, "1v3 group has one side A member")
+		_expect(_string_array(group.get("side_b_member_ids", [])).size() == 3, "1v3 group has three side B members")
+		_expect(_string_array(group.get("support_member_ids", [])).size() == 2, "1v3 extras are classified as support")
+
+
+func _validate_5v5_groups() -> void:
+	var result := _resolve_member_case("five_v_five", 5, 5)
+	_validate_group_contract(result, _member_ids("five_v_five.a", 5), _member_ids("five_v_five.b", 5), [], "5v5")
+	var groups := _groups(result)
+	_expect(groups.size() == 5, "5v5 creates five duel groups")
+	for group in groups:
+		if group is Dictionary:
+			_expect(_group_size(group) == 2, "5v5 group size is two")
+
+
+func _validate_50v50_groups() -> void:
+	var excluded_ids := ["fifty_v_fifty.a.dead.001", "fifty_v_fifty.b.dead.001"]
+	var first_result := _resolve_member_case("fifty_v_fifty", 50, 50, 1, 1, "50v50-first")
+	var second_result := _resolve_member_case("fifty_v_fifty", 50, 50, 1, 1, "50v50-second")
+	_validate_group_contract(first_result, _member_ids("fifty_v_fifty.a", 50), _member_ids("fifty_v_fifty.b", 50), excluded_ids, "50v50")
+	_expect(_group_signature(first_result) == _group_signature(second_result), "50v50 grouping is deterministic independent of BattleSim seed")
+	_expect(_groups(first_result).size() == 50, "50v50 creates one bounded duel group per pair")
+
+
+func _validate_squad_fallback_groups() -> void:
+	var encounter_id := "encounter:validation:fallback_groups"
+	var result: Dictionary = BATTLE_SIM_SCRIPT.resolve_encounter(
+		{"encounter_id": encounter_id, "created_tick": 1, "squad_ids": ["fallback.a", "fallback.b"]},
+		_squad_fallback_record("fallback.a", 12),
+		_squad_fallback_record("fallback.b", 8),
+		{"encounter_id": encounter_id, "current_tick": CURRENT_TICK, "rounds": 2, "seed": "fallback-groups"}
+	)
+	var groups := _groups(result)
+	_expect(groups.size() == 1, "Fallback combat emits one engagement group")
+	if groups.size() == 1 and groups[0] is Dictionary:
+		var group: Dictionary = groups[0]
+		_expect(bool(group.get("uses_squad_fallback", false)), "Fallback group is marked as squad fallback")
+		_expect(str(group.get("side_a_primary_id", "")) == "fallback.a", "Fallback group side A primary is squad ID")
+		_expect(str(group.get("side_b_primary_id", "")) == "fallback.b", "Fallback group side B primary is squad ID")
+		_expect(_group_size(group) == 0, "Fallback group does not invent member IDs")
+	_validate_beat_group_refs(result, "Fallback")
+	for beat in _beats(result):
+		if beat is Dictionary:
+			_expect(str((beat as Dictionary).get("attacker_member_id", "")).is_empty(), "Fallback beat keeps attacker_member_id empty")
+			_expect(str((beat as Dictionary).get("defender_member_id", "")).is_empty(), "Fallback beat keeps defender_member_id empty")
+
+
+func _validate_group_contract(result: Dictionary, expected_side_a_ids: Array[String], expected_side_b_ids: Array[String], excluded_ids: Array, label: String) -> void:
+	_validate_grouping_summary(result, label)
+	var groups := _groups(result)
+	_expect(not groups.is_empty(), "%s emits engagement groups" % label)
+	var assigned_ids := {}
+	var expected_ids := {}
+	for id in expected_side_a_ids:
+		expected_ids[id] = true
+	for id in expected_side_b_ids:
+		expected_ids[id] = true
+	for group in groups:
+		if not (group is Dictionary):
+			_failures.append("%s group entry is not a Dictionary" % label)
+			continue
+		var group_record: Dictionary = group
+		var group_id := str(group_record.get("engagement_group_id", "")).strip_edges()
+		_expect(not group_id.is_empty(), "%s group has stable engagement_group_id" % label)
+		_expect(str(group_record.get("encounter_id", "")).strip_edges() != "", "%s group has encounter_id" % label)
+		_expect(int(group_record.get("max_group_size", 0)) == MAX_GROUP_SIZE, "%s group records max size" % label)
+		_expect(_group_size(group_record) <= MAX_GROUP_SIZE, "%s group size is bounded" % label)
+		var side_a_ids := _string_array(group_record.get("side_a_member_ids", []))
+		var side_b_ids := _string_array(group_record.get("side_b_member_ids", []))
+		if not side_a_ids.is_empty():
+			_expect(side_a_ids.has(str(group_record.get("side_a_primary_id", ""))), "%s side A primary is assigned to side A" % label)
+		if not side_b_ids.is_empty():
+			_expect(side_b_ids.has(str(group_record.get("side_b_primary_id", ""))), "%s side B primary is assigned to side B" % label)
+		_record_assigned_ids(assigned_ids, expected_ids, side_a_ids, label)
+		_record_assigned_ids(assigned_ids, expected_ids, side_b_ids, label)
+		_validate_classification_subset(group_record, assigned_ids, label)
+	_expect(assigned_ids.size() == expected_ids.size(), "%s assigns every living participant exactly once" % label)
+	for expected_id in expected_ids.keys():
+		_expect(assigned_ids.has(expected_id), "%s does not lose living participant %s" % [label, str(expected_id)])
+	for excluded_id in excluded_ids:
+		_expect(not assigned_ids.has(str(excluded_id)), "%s excludes non-living participant %s" % [label, str(excluded_id)])
+	_validate_beat_group_refs(result, label)
+
+
+func _validate_grouping_summary(result: Dictionary, label: String) -> void:
+	var summary: Dictionary = result.get("engagement_grouping", {}) if result.get("engagement_grouping", {}) is Dictionary else {}
+	_expect(str(summary.get("strategy", "")) == "deterministic_sorted_bounded", "%s grouping strategy is deterministic bounded sort" % label)
+	_expect(str(summary.get("complexity", "")) == "O(N log N) sort + O(N) assignment", "%s grouping declares non-quadratic complexity" % label)
+	_expect(int(summary.get("max_group_size", 0)) == MAX_GROUP_SIZE, "%s grouping summary records max group size" % label)
+
+
+func _record_assigned_ids(assigned_ids: Dictionary, expected_ids: Dictionary, ids: Array[String], label: String) -> void:
+	for id in ids:
+		_expect(expected_ids.has(id), "%s assigned unexpected participant %s" % [label, id])
+		_expect(not assigned_ids.has(id), "%s does not duplicate participant %s across groups" % [label, id])
+		assigned_ids[id] = true
+
+
+func _validate_classification_subset(group_record: Dictionary, assigned_ids: Dictionary, label: String) -> void:
+	var side_ids := {}
+	for id in _string_array(group_record.get("side_a_member_ids", [])):
+		side_ids[id] = true
+	for id in _string_array(group_record.get("side_b_member_ids", [])):
+		side_ids[id] = true
+	for id in _string_array(group_record.get("support_member_ids", [])):
+		_expect(side_ids.has(id) or assigned_ids.has(id), "%s support id belongs to an assigned member" % label)
+	for id in _string_array(group_record.get("reserve_member_ids", [])):
+		_expect(side_ids.has(id) or assigned_ids.has(id), "%s reserve id belongs to an assigned member" % label)
+
+
+func _validate_beat_group_refs(result: Dictionary, label: String) -> void:
+	var group_ids := {}
+	for group in _groups(result):
+		if group is Dictionary:
+			var group_id := str((group as Dictionary).get("engagement_group_id", "")).strip_edges()
+			if not group_id.is_empty():
+				group_ids[group_id] = true
+	_expect(not group_ids.is_empty(), "%s has engagement group ids" % label)
+	for beat in _beats(result):
+		if beat is Dictionary:
+			var beat_group_id := str((beat as Dictionary).get("engagement_group_id", "")).strip_edges()
+			_expect(not beat_group_id.is_empty(), "%s beat has engagement_group_id" % label)
+			_expect(group_ids.has(beat_group_id), "%s beat group references existing group" % label)
+
+
+func _resolve_member_case(label: String, side_a_count: int, side_b_count: int, dead_a_count := 0, dead_b_count := 0, seed := "") -> Dictionary:
+	var encounter_id := "encounter:validation:%s" % label
+	return BATTLE_SIM_SCRIPT.resolve_encounter(
+		{"encounter_id": encounter_id, "created_tick": 1, "squad_ids": ["%s.a" % label, "%s.b" % label]},
+		_squad_record("%s.a" % label, _member_records("%s.a" % label, side_a_count, dead_a_count)),
+		_squad_record("%s.b" % label, _member_records("%s.b" % label, side_b_count, dead_b_count)),
+		{"encounter_id": encounter_id, "current_tick": CURRENT_TICK, "rounds": 3, "seed": seed if not seed.is_empty() else label}
+	)
+
+
+func _squad_record(squad_id: String, member_records: Array[Dictionary]) -> Dictionary:
+	return {
+		"squad_id": squad_id,
+		"member_count": member_records.size(),
+		"member_records": member_records,
+		"member_records_are_canonical": true,
+		"strength": 80.0,
+		"base_strength": 10.0,
+		"base_attack_damage": 12.0,
+		"max_hp": 100.0,
+		"combat_stance": 1,
+		"morale": 1.0,
+		"supplies": 40.0,
+	}
+
+
+func _squad_fallback_record(squad_id: String, member_count: int) -> Dictionary:
+	return {
+		"squad_id": squad_id,
+		"member_count": member_count,
+		"strength": 80.0,
+		"base_strength": 10.0,
+		"base_attack_damage": 12.0,
+		"max_hp": 100.0,
+		"combat_stance": 1,
+		"morale": 1.0,
+		"supplies": 40.0,
+	}
+
+
+func _member_records(prefix: String, alive_count: int, dead_count: int) -> Array[Dictionary]:
+	var records: Array[Dictionary] = []
+	for index in range(1, alive_count + 1):
+		records.append(_member_record("%s.%03d" % [prefix, index], true))
+	for index in range(1, dead_count + 1):
+		records.append(_member_record("%s.dead.%03d" % [prefix, index], false))
+	return records
+
+
+func _member_record(member_id: String, alive: bool) -> Dictionary:
+	return {
+		"actor_id": member_id,
+		"stable_id": member_id,
+		"member_id": member_id,
+		"member_name": member_id,
+		"life_state": LIFE_STATE_ALIVE if alive else LIFE_STATE_DEAD,
+		"hp": 100.0 if alive else 0.0,
+		"max_hp": 100.0,
+		"blood": 5.0 if alive else 0.0,
+		"max_blood": 5.0,
+		"base_attack_damage": 12.0,
+		"base_dodge_chance": 0.0,
+		"base_block_chance": 0.0,
+		"skill_levels": {
+			"attribute.strength": 4.0,
+			"attribute.perception": 4.0,
+			"attribute.dexterity": 4.0,
+			"attribute.toughness": 4.0,
+			"attribute.endurance": 4.0,
+			"combat.swords_one_handed": 5.0,
+			"combat.axes_one_handed": 3.0,
+			"combat.daggers": 2.0,
+			"combat.unarmed": 2.0,
+			"combat.shields": 3.0,
+		},
+	}
+
+
+func _member_ids(prefix: String, count: int) -> Array[String]:
+	var ids: Array[String] = []
+	for index in range(1, count + 1):
+		ids.append("%s.%03d" % [prefix, index])
+	return ids
+
+
+func _groups(result: Dictionary) -> Array:
+	return result.get("engagement_groups", []) if result.get("engagement_groups", []) is Array else []
+
+
+func _beats(result: Dictionary) -> Array:
+	return result.get("beats", []) if result.get("beats", []) is Array else []
+
+
+func _group_size(group) -> int:
+	if not (group is Dictionary):
+		return 0
+	return _string_array((group as Dictionary).get("side_a_member_ids", [])).size() + _string_array((group as Dictionary).get("side_b_member_ids", [])).size()
+
+
+func _group_signature(result: Dictionary) -> String:
+	var parts: Array[String] = []
+	for group in _groups(result):
+		if group is Dictionary:
+			var record: Dictionary = group
+			parts.append("%s|%s|%s|%s" % [
+				str(record.get("engagement_group_id", "")),
+				_join_strings(_string_array(record.get("side_a_member_ids", [])), ","),
+				_join_strings(_string_array(record.get("side_b_member_ids", [])), ","),
+				str(record.get("group_role", "")),
+			])
+	return _join_strings(parts, ";")
+
+
+func _string_array(value) -> Array[String]:
+	var result: Array[String] = []
+	if not (value is Array) and not (value is PackedStringArray):
+		return result
+	for entry in value:
+		var text := str(entry).strip_edges()
+		if not text.is_empty():
+			result.append(text)
+	return result
+
+
+func _join_strings(parts: Array[String], delimiter: String) -> String:
+	var result := ""
+	for index in range(parts.size()):
+		if index > 0:
+			result += delimiter
+		result += parts[index]
+	return result
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("COMBAT_ENGAGEMENT_GROUPS_VALIDATION_OK")
+		quit(0)
+		return
+	for failure in _failures:
+		push_error(failure)
+	quit(1)
+
+
+func _expect(condition: bool, message: String) -> void:
+	if not condition:
+		_failures.append(message)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battle simulation now organizes squad members into engagement groups, structuring how members are paired and selected during combat encounters with bounded group sizing and stable group identifiers.

* **Tests**
  * Added comprehensive validation suite for engagement groups across multiple squad configurations (1v1, 1v3, 5v5, 50v50), verifying grouping logic, participant assignment, and beat references.

* **Documentation**
  * Updated combat system documentation to formalize engagement group contract specifications, deterministic grouping strategy, and member fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->