### PR TITLE
Move Rustdead cinder visuals to body projection

### DIFF
--- a/scripts/characters/rustdead_humanoid_character.gd
+++ b/scripts/characters/rustdead_humanoid_character.gd
@@ -20,12 +20,6 @@ const RUSTDEAD_ANIMATION_NAMES: Array[String] = [
 	RUSTDEAD_SCRATCH_ANIMATION_NAME,
 	RUSTDEAD_SPAWN_ANIMATION_NAME,
 ]
-const CINDER_BURNED_MATERIAL_META := "cinder_burned"
-const CINDER_SCORCH_OVERLAY_META := "cinder_scorch_overlay"
-
-static var _cinder_burn_overlay_material: Material
-static var _cinder_burn_overlay_texture: Texture2D
-
 @export var fresh_skin_color := Color(0.64, 0.19, 0.16, 1.0)
 @export var cinder_burn_duration_seconds := 2.0
 @export var rustdead_tier_definition: Resource
@@ -34,8 +28,6 @@ static var _cinder_burn_overlay_texture: Texture2D
 
 var _cinder_burn_remaining := 0.0
 var _cinder_burn_attacker: HumanoidCharacter
-var _cinder_burn_effect: Node3D
-var _cinder_burn_fire_seed := 0.0
 var _allow_cinder_true_death := false
 var _is_cinder_burned := false
 
@@ -46,9 +38,6 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
-	_clear_cinder_burned_visuals()
-	_free_rustdead_visual_root_for_exit()
-	_clear_cinder_burn_effect()
 	super._exit_tree()
 
 
@@ -57,14 +46,12 @@ func _process(delta: float) -> void:
 	super._process(delta)
 
 
-func _setup_character_visual() -> void:
-	super._setup_character_visual()
-	if _is_cinder_burned:
-		_apply_cinder_burned_visuals()
-
-
 func _create_body_projection() -> BodyProjection:
 	return RustdeadBodyProjection.new()
+
+
+func _get_rustdead_body_projection() -> RustdeadBodyProjection:
+	return (_body as RustdeadBodyProjection) if _body != null and is_instance_valid(_body) else null
 
 
 func requires_fire_to_die() -> bool:
@@ -101,11 +88,8 @@ func is_cinder_burned() -> bool:
 
 
 func has_cinder_burned_visuals() -> bool:
-	var visual_root := get_character_visual_root()
-	if visual_root != null and _node_has_cinder_burned_material(visual_root):
-		return true
-	var body_mesh := get_node_or_null("BodyMesh")
-	return body_mesh != null and _node_has_cinder_burned_material(body_mesh)
+	var body := _get_rustdead_body_projection()
+	return body != null and body.has_cinder_burned_visuals()
 
 
 func begin_cinder_burn(attacker: HumanoidCharacter = null) -> bool:
@@ -113,14 +97,16 @@ func begin_cinder_burn(attacker: HumanoidCharacter = null) -> bool:
 		return false
 	_cinder_burn_attacker = attacker
 	_cinder_burn_remaining = maxf(0.05, cinder_burn_duration_seconds)
-	_cinder_burn_fire_seed = _rng.randf() * TAU
 	_downed_recover_delay_remaining = maxf(_downed_recover_delay_remaining, _cinder_burn_remaining + 1.0)
 	if _is_getting_up:
 		_cancel_get_up()
 	_is_cinder_burned = true
-	_apply_cinder_burned_visuals()
+	var body := _get_rustdead_body_projection()
+	if body != null:
+		body.begin_cinder_burn_visuals()
 	_enter_cinder_dead_state_in_place()
-	_spawn_cinder_burn_effect()
+	if body != null:
+		body.spawn_cinder_burn_effect(_cinder_burn_remaining, cinder_burn_duration_seconds)
 	_show_world_notice("Burning", Color(1.0, 0.45, 0.12, 1.0), 1.6)
 	state_changed.emit()
 	return true
@@ -212,121 +198,17 @@ func _process_cinder_burn(delta: float) -> void:
 		return
 	_cinder_burn_remaining = maxf(0.0, _cinder_burn_remaining - delta)
 	_downed_recover_delay_remaining = maxf(_downed_recover_delay_remaining, _cinder_burn_remaining + 0.5)
-	_update_cinder_burn_effect_position()
-	_update_cinder_burn_effect()
+	var body := _get_rustdead_body_projection()
+	if body != null:
+		body.update_cinder_burn_visuals(_cinder_burn_remaining, cinder_burn_duration_seconds)
 	if _cinder_burn_remaining <= 0.0:
 		_finish_cinder_burn()
 
 
-func _spawn_cinder_burn_effect() -> void:
-	_clear_cinder_burn_effect()
-	_cinder_burn_effect = Node3D.new()
-	_cinder_burn_effect.name = "CinderBurnEffect"
-	add_child(_cinder_burn_effect)
-	_cinder_burn_effect.top_level = true
-	_update_cinder_burn_effect_position()
-	for index in range(7):
-		var flame := MeshInstance3D.new()
-		flame.name = "Flame%02d" % index
-		var flame_mesh := SphereMesh.new()
-		flame_mesh.radius = 0.32
-		flame_mesh.height = 0.75
-		flame_mesh.radial_segments = 12
-		flame_mesh.rings = 6
-		flame.mesh = flame_mesh
-		var flame_material := StandardMaterial3D.new()
-		flame_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		flame_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-		flame_material.albedo_color = Color(1.0, 0.32 + float(index % 3) * 0.14, 0.04, 0.72)
-		flame_material.emission_enabled = true
-		flame_material.emission = Color(1.0, 0.33, 0.06, 1.0)
-		flame_material.emission_energy_multiplier = 2.8
-		flame.material_override = flame_material
-		var angle := TAU * float(index) / 7.0
-		var radius := 0.18 + 0.18 * float(index % 2)
-		flame.position = Vector3(cos(angle) * radius, 0.16 + 0.04 * float(index % 3), sin(angle) * radius)
-		var base_scale := Vector3(0.34 + 0.04 * float(index % 3), 0.95 + 0.12 * float(index % 2), 0.34 + 0.03 * float(index % 4))
-		flame.scale = base_scale
-		flame.set_meta("cinder_flame", true)
-		flame.set_meta("base_scale", base_scale)
-		flame.set_meta("base_position", flame.position)
-		flame.set_meta("phase", _cinder_burn_fire_seed + float(index) * 0.91)
-		_cinder_burn_effect.add_child(flame)
-	for index in range(4):
-		var smoke := MeshInstance3D.new()
-		smoke.name = "Smoke%02d" % index
-		var smoke_mesh := SphereMesh.new()
-		smoke_mesh.radius = 0.38
-		smoke_mesh.height = 0.42
-		smoke_mesh.radial_segments = 10
-		smoke_mesh.rings = 5
-		smoke.mesh = smoke_mesh
-		var smoke_material := StandardMaterial3D.new()
-		smoke_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		smoke_material.albedo_color = Color(0.08, 0.07, 0.06, 0.26)
-		smoke.material_override = smoke_material
-		var angle := _cinder_burn_fire_seed + TAU * float(index) / 4.0
-		smoke.position = Vector3(cos(angle) * 0.24, 0.85 + 0.12 * float(index), sin(angle) * 0.24)
-		var base_scale := Vector3.ONE * (0.65 + float(index) * 0.08)
-		smoke.scale = base_scale
-		smoke.set_meta("cinder_smoke", true)
-		smoke.set_meta("base_scale", base_scale)
-		smoke.set_meta("base_position", smoke.position)
-		smoke.set_meta("phase", _cinder_burn_fire_seed + float(index) * 1.37)
-		_cinder_burn_effect.add_child(smoke)
-	var light := OmniLight3D.new()
-	light.name = "CinderLight"
-	light.light_color = Color(1.0, 0.42, 0.12, 1.0)
-	light.light_energy = 2.2
-	light.omni_range = 4.0
-	light.position = Vector3(0.0, 0.9, 0.0)
-	light.set_meta("cinder_light", true)
-	_cinder_burn_effect.add_child(light)
-	_update_cinder_burn_effect()
-
-
-func _update_cinder_burn_effect_position() -> void:
-	if _cinder_burn_effect == null or not is_instance_valid(_cinder_burn_effect):
-		return
-	_cinder_burn_effect.global_position = get_follow_anchor_position() + Vector3(0.0, 0.35, 0.0)
-
-
-func _update_cinder_burn_effect() -> void:
-	if _cinder_burn_effect == null or not is_instance_valid(_cinder_burn_effect):
-		return
-	var duration := maxf(cinder_burn_duration_seconds, 0.05)
-	var elapsed := duration - _cinder_burn_remaining
-	var intensity := minf(1.0, elapsed / 0.75) * minf(1.0, _cinder_burn_remaining / 3.0)
-	for child in _cinder_burn_effect.get_children():
-		if child is MeshInstance3D and bool(child.get_meta("cinder_flame", false)):
-			var base_scale: Vector3 = child.get_meta("base_scale")
-			var base_position: Vector3 = child.get_meta("base_position")
-			var phase := float(child.get_meta("phase", 0.0))
-			var pulse := 0.72 + 0.28 * sin(elapsed * 9.0 + phase)
-			child.scale = base_scale * maxf(0.01, pulse * intensity)
-			child.position = base_position + Vector3(0.0, sin(elapsed * 7.0 + phase) * 0.08 * intensity, 0.0)
-			var material := child.material_override as StandardMaterial3D
-			if material != null:
-				var alpha := clampf(0.18 + 0.62 * intensity, 0.0, 0.82)
-				material.albedo_color.a = alpha
-				material.emission_energy_multiplier = 1.0 + 2.4 * intensity
-		elif child is MeshInstance3D and bool(child.get_meta("cinder_smoke", false)):
-			var base_scale: Vector3 = child.get_meta("base_scale")
-			var base_position: Vector3 = child.get_meta("base_position")
-			var phase := float(child.get_meta("phase", 0.0))
-			var drift := Vector3(cos(elapsed * 1.1 + phase), 0.0, sin(elapsed * 0.9 + phase)) * 0.08 * intensity
-			child.position = base_position + drift + Vector3(0.0, sin(elapsed * 1.7 + phase) * 0.08, 0.0)
-			child.scale = base_scale * (0.75 + 0.35 * intensity + 0.08 * sin(elapsed * 2.0 + phase))
-			var material := child.material_override as StandardMaterial3D
-			if material != null:
-				material.albedo_color.a = clampf(0.05 + 0.22 * intensity, 0.0, 0.28)
-		elif child is OmniLight3D and bool(child.get_meta("cinder_light", false)):
-			var light := child as OmniLight3D
-			light.light_energy = intensity * (1.4 + 0.8 * sin(elapsed * 12.0 + _cinder_burn_fire_seed))
-
-
 func _finish_cinder_burn() -> void:
-	_clear_cinder_burn_effect()
+	var body := _get_rustdead_body_projection()
+	if body != null:
+		body.finish_cinder_burn_visuals()
 	_cinder_burn_attacker = null
 	_show_world_notice("Burned", Color(0.9, 0.28, 0.08, 1.0), 1.6)
 
@@ -353,165 +235,3 @@ func _enter_cinder_dead_state_in_place() -> void:
 	life_state_changed.emit(previous_state, life_state)
 	died.emit(self)
 	state_changed.emit()
-
-
-func _clear_cinder_burn_effect() -> void:
-	if _cinder_burn_effect == null:
-		return
-	var effect := _cinder_burn_effect
-	_cinder_burn_effect = null
-	if is_instance_valid(effect):
-		var parent := effect.get_parent()
-		if parent != null:
-			parent.remove_child(effect)
-		effect.free()
-
-
-func _apply_cinder_burned_visuals() -> void:
-	var visual_root := get_character_visual_root()
-	if visual_root != null:
-		_apply_cinder_burn_overlay(visual_root)
-	var body_mesh := get_node_or_null("BodyMesh")
-	if body_mesh != null:
-		_apply_cinder_burn_overlay(body_mesh)
-
-
-func _clear_cinder_burned_visuals() -> void:
-	var visual_root := get_character_visual_root()
-	if visual_root != null:
-		_clear_cinder_burn_overlay(visual_root)
-	var body_mesh := get_node_or_null("BodyMesh")
-	if body_mesh != null:
-		_clear_cinder_burn_overlay(body_mesh)
-
-
-func _free_rustdead_visual_root_for_exit() -> void:
-	var visual_root := get_character_visual_root()
-	if visual_root == null:
-		return
-	_strip_meshes_for_exit(visual_root)
-	var parent := visual_root.get_parent()
-	if parent != null:
-		parent.remove_child(visual_root)
-	visual_root.free()
-
-
-func _strip_meshes_for_exit(root: Node) -> void:
-	if root == null:
-		return
-	if root is MeshInstance3D:
-		(root as MeshInstance3D).mesh = null
-	for child in root.get_children():
-		_strip_meshes_for_exit(child)
-
-
-func _apply_cinder_burn_overlay(root: Node) -> void:
-	if root == null:
-		return
-	if root is MeshInstance3D:
-		_apply_cinder_burn_overlay_to_mesh(root as MeshInstance3D)
-	for child in root.get_children():
-		_apply_cinder_burn_overlay(child)
-
-
-func _clear_cinder_burn_overlay(root: Node) -> void:
-	if root == null:
-		return
-	if root is MeshInstance3D:
-		var mesh_instance := root as MeshInstance3D
-		if mesh_instance.material_overlay != null and bool(mesh_instance.material_overlay.get_meta(CINDER_SCORCH_OVERLAY_META, false)):
-			mesh_instance.material_overlay = _get_cinder_burn_clear_material()
-		if mesh_instance.material_override != null and bool(mesh_instance.material_override.get_meta(CINDER_SCORCH_OVERLAY_META, false)):
-			mesh_instance.material_override = _get_cinder_burn_clear_material()
-	for child in root.get_children():
-		_clear_cinder_burn_overlay(child)
-
-
-func _apply_cinder_burn_overlay_to_mesh(mesh_instance: MeshInstance3D) -> void:
-	mesh_instance.material_override = _get_cinder_burn_overlay_material()
-
-
-func _node_has_cinder_burned_material(root: Node) -> bool:
-	if root == null:
-		return false
-	if root is MeshInstance3D and _mesh_has_cinder_burned_material(root as MeshInstance3D):
-		return true
-	for child in root.get_children():
-		if _node_has_cinder_burned_material(child):
-			return true
-	return false
-
-
-func _mesh_has_cinder_burned_material(mesh_instance: MeshInstance3D) -> bool:
-	if mesh_instance.material_overlay != null and bool(mesh_instance.material_overlay.get_meta(CINDER_BURNED_MATERIAL_META, false)):
-		return true
-	if mesh_instance.material_override != null and bool(mesh_instance.material_override.get_meta(CINDER_BURNED_MATERIAL_META, false)):
-		return true
-	for surface_index in range(mesh_instance.get_surface_override_material_count()):
-		var material := mesh_instance.get_surface_override_material(surface_index)
-		if material != null and bool(material.get_meta(CINDER_BURNED_MATERIAL_META, false)):
-			return true
-	return false
-
-
-func _get_cinder_burn_overlay_material() -> Material:
-	if _cinder_burn_overlay_material != null:
-		return _cinder_burn_overlay_material
-	var material := StandardMaterial3D.new()
-	material.resource_name = "Cinder Burn Overlay"
-	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	material.cull_mode = BaseMaterial3D.CULL_DISABLED
-	material.albedo_texture = _get_cinder_burn_overlay_texture()
-	material.albedo_color = Color(0.004, 0.0035, 0.003, 1.0)
-	material.roughness = 1.0
-	material.set_meta(CINDER_BURNED_MATERIAL_META, true)
-	material.set_meta(CINDER_SCORCH_OVERLAY_META, true)
-	_cinder_burn_overlay_material = material
-	return _cinder_burn_overlay_material
-
-
-func _get_cinder_burn_clear_material() -> Material:
-	var material := StandardMaterial3D.new()
-	material.resource_name = "Cleared Cinder Surface"
-	material.albedo_color = Color(0.02, 0.018, 0.015, 1.0)
-	material.roughness = 1.0
-	return material
-
-
-func _get_cinder_burn_overlay_texture() -> Texture2D:
-	if _cinder_burn_overlay_texture != null:
-		return _cinder_burn_overlay_texture
-	var size := 128
-	var image := Image.create(size, size, false, Image.FORMAT_RGBA8)
-	for y in range(size):
-		for x in range(size):
-			var uv := Vector2(float(x) / float(size - 1), float(y) / float(size - 1))
-			var mask := _get_cinder_burn_overlay_mask(uv, x, y)
-			var ash := _cinder_overlay_noise01(x, y, 29)
-			var shade := 0.006 + ash * 0.028
-			var color := Color(shade, shade * 0.9, shade * 0.78, mask)
-			if mask > 0.58 and _cinder_overlay_noise01(x, y, 53) > 0.88:
-				color = Color(0.18, 0.16, 0.13, mask * 0.86)
-			image.set_pixel(x, y, color)
-	_cinder_burn_overlay_texture = ImageTexture.create_from_image(image)
-	return _cinder_burn_overlay_texture
-
-
-func _get_cinder_burn_overlay_mask(uv: Vector2, x: int, y: int) -> float:
-	var center := uv - Vector2(0.5, 0.5)
-	var radial := maxf(0.0, 1.0 - center.length() / 0.92)
-	var lobe_a := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.32, 0.62)) / 0.52)
-	var lobe_b := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.68, 0.38)) / 0.48)
-	var lobe_c := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.55, 0.77)) / 0.44)
-	var lobe_d := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.46, 0.28)) / 0.36)
-	var crack := 0.5 + 0.5 * sin((uv.x * 15.0 + uv.y * 8.0 + _cinder_overlay_noise01(x, y, 7) * 2.0) * PI)
-	var grain := _cinder_overlay_noise01(x, y, 13)
-	var mask := radial * 0.7 + lobe_a * 0.46 + lobe_b * 0.44 + lobe_c * 0.34 + lobe_d * 0.26 + crack * 0.2 + grain * 0.24 - 0.13
-	mask = clampf(mask, 0.0, 1.0)
-	return mask * mask * (3.0 - 2.0 * mask)
-
-
-func _cinder_overlay_noise01(x: int, y: int, salt: int) -> float:
-	var value := sin(float(x * 23 + salt * 41) * 12.9898 + float(y * 31 + salt * 17) * 78.233) * 43758.5453
-	return value - floor(value)

--- a/scripts/projection/rustdead_body_projection.gd
+++ b/scripts/projection/rustdead_body_projection.gd
@@ -3,10 +3,32 @@ class_name RustdeadBodyProjection
 
 # Rustdead (zombie) humanoid visual adapter. PRESENTATION ONLY -- never owns truth.
 #
-# Holds the rustdead-specific clip overrides migrated from RustdeadHumanoidCharacter:
-# remapped zombie locomotion/idle clips and the extra zombie clip set. Rustdead
-# constants are read through the untyped `actor` at runtime (the actor is a
-# RustdeadHumanoidCharacter, which defines them). Cinder-burn visuals migrate later.
+# Holds rustdead-specific presentation: remapped zombie clips, the extra zombie
+# clip set, automatic eyebrow policy, and cinder-burn visuals. Rustdead constants
+# are read through the untyped `actor` at runtime (the actor is a
+# RustdeadHumanoidCharacter, which defines them).
+
+const CINDER_BURNED_MATERIAL_META := "cinder_burned"
+const CINDER_SCORCH_OVERLAY_META := "cinder_scorch_overlay"
+
+static var _cinder_burn_overlay_material: Material
+static var _cinder_burn_overlay_texture: Texture2D
+
+var _cinder_burn_effect: Node3D
+var _cinder_burn_fire_seed := 0.0
+var _cinder_burn_visual_rng := RandomNumberGenerator.new()
+
+
+func _exit_tree() -> void:
+	clear_cinder_burned_visuals()
+	_free_rustdead_visual_root_for_exit()
+	clear_cinder_burn_effect()
+
+
+func setup_visual() -> void:
+	super.setup_visual()
+	if actor != null and actor.is_cinder_burned():
+		apply_cinder_burned_visuals()
 
 
 func play_clip(animation_name: String, speed_ratio: float = 0.0, force_restart: bool = false, blend_seconds: float = DEFAULT_MOVE_BLEND_SECONDS) -> bool:
@@ -61,3 +83,295 @@ func apply_automatic_eyebrow_style() -> void:
 		return
 	actor.appearance_data.eyebrow_style = null
 	actor.appearance_data.eyebrow_color = Color(0.08, 0.015, 0.018, 1.0)
+
+
+func begin_cinder_burn_visuals() -> void:
+	_cinder_burn_visual_rng.randomize()
+	_cinder_burn_fire_seed = _cinder_burn_visual_rng.randf() * TAU
+	apply_cinder_burned_visuals()
+
+
+func spawn_cinder_burn_effect(remaining_seconds: float, duration_seconds: float) -> void:
+	clear_cinder_burn_effect()
+	_cinder_burn_effect = Node3D.new()
+	_cinder_burn_effect.name = "CinderBurnEffect"
+	add_child(_cinder_burn_effect)
+	_cinder_burn_effect.top_level = true
+	_update_cinder_burn_effect_position()
+	for index in range(7):
+		var flame := MeshInstance3D.new()
+		flame.name = "Flame%02d" % index
+		var flame_mesh := SphereMesh.new()
+		flame_mesh.radius = 0.32
+		flame_mesh.height = 0.75
+		flame_mesh.radial_segments = 12
+		flame_mesh.rings = 6
+		flame.mesh = flame_mesh
+		var flame_material := StandardMaterial3D.new()
+		flame_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+		flame_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+		flame_material.albedo_color = Color(1.0, 0.32 + float(index % 3) * 0.14, 0.04, 0.72)
+		flame_material.emission_enabled = true
+		flame_material.emission = Color(1.0, 0.33, 0.06, 1.0)
+		flame_material.emission_energy_multiplier = 2.8
+		flame.material_override = flame_material
+		var angle := TAU * float(index) / 7.0
+		var radius := 0.18 + 0.18 * float(index % 2)
+		flame.position = Vector3(cos(angle) * radius, 0.16 + 0.04 * float(index % 3), sin(angle) * radius)
+		var base_scale := Vector3(0.34 + 0.04 * float(index % 3), 0.95 + 0.12 * float(index % 2), 0.34 + 0.03 * float(index % 4))
+		flame.scale = base_scale
+		flame.set_meta("cinder_flame", true)
+		flame.set_meta("base_scale", base_scale)
+		flame.set_meta("base_position", flame.position)
+		flame.set_meta("phase", _cinder_burn_fire_seed + float(index) * 0.91)
+		_cinder_burn_effect.add_child(flame)
+	for index in range(4):
+		var smoke := MeshInstance3D.new()
+		smoke.name = "Smoke%02d" % index
+		var smoke_mesh := SphereMesh.new()
+		smoke_mesh.radius = 0.38
+		smoke_mesh.height = 0.42
+		smoke_mesh.radial_segments = 10
+		smoke_mesh.rings = 5
+		smoke.mesh = smoke_mesh
+		var smoke_material := StandardMaterial3D.new()
+		smoke_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+		smoke_material.albedo_color = Color(0.08, 0.07, 0.06, 0.26)
+		smoke.material_override = smoke_material
+		var angle := _cinder_burn_fire_seed + TAU * float(index) / 4.0
+		smoke.position = Vector3(cos(angle) * 0.24, 0.85 + 0.12 * float(index), sin(angle) * 0.24)
+		var base_scale := Vector3.ONE * (0.65 + float(index) * 0.08)
+		smoke.scale = base_scale
+		smoke.set_meta("cinder_smoke", true)
+		smoke.set_meta("base_scale", base_scale)
+		smoke.set_meta("base_position", smoke.position)
+		smoke.set_meta("phase", _cinder_burn_fire_seed + float(index) * 1.37)
+		_cinder_burn_effect.add_child(smoke)
+	var light := OmniLight3D.new()
+	light.name = "CinderLight"
+	light.light_color = Color(1.0, 0.42, 0.12, 1.0)
+	light.light_energy = 2.2
+	light.omni_range = 4.0
+	light.position = Vector3(0.0, 0.9, 0.0)
+	light.set_meta("cinder_light", true)
+	_cinder_burn_effect.add_child(light)
+	update_cinder_burn_visuals(remaining_seconds, duration_seconds)
+
+
+func update_cinder_burn_visuals(remaining_seconds: float, duration_seconds: float) -> void:
+	_update_cinder_burn_effect_position()
+	_update_cinder_burn_effect(remaining_seconds, duration_seconds)
+
+
+func finish_cinder_burn_visuals() -> void:
+	clear_cinder_burn_effect()
+
+
+func clear_cinder_burn_effect() -> void:
+	if _cinder_burn_effect == null:
+		return
+	var effect := _cinder_burn_effect
+	_cinder_burn_effect = null
+	if is_instance_valid(effect):
+		var parent := effect.get_parent()
+		if parent != null:
+			parent.remove_child(effect)
+		effect.free()
+
+
+func apply_cinder_burned_visuals() -> void:
+	var visual_root := get_visual_root()
+	if visual_root != null:
+		_apply_cinder_burn_overlay(visual_root)
+	var body_mesh := actor.get_node_or_null("BodyMesh")
+	if body_mesh != null:
+		_apply_cinder_burn_overlay(body_mesh)
+
+
+func clear_cinder_burned_visuals() -> void:
+	var visual_root := get_visual_root()
+	if visual_root != null:
+		_clear_cinder_burn_overlay(visual_root)
+	var body_mesh := actor.get_node_or_null("BodyMesh") if actor != null else null
+	if body_mesh != null:
+		_clear_cinder_burn_overlay(body_mesh)
+
+
+func has_cinder_burned_visuals() -> bool:
+	var visual_root := get_visual_root()
+	if visual_root != null and _node_has_cinder_burned_material(visual_root):
+		return true
+	var body_mesh := actor.get_node_or_null("BodyMesh")
+	return body_mesh != null and _node_has_cinder_burned_material(body_mesh)
+
+
+func _update_cinder_burn_effect_position() -> void:
+	if _cinder_burn_effect == null or not is_instance_valid(_cinder_burn_effect):
+		return
+	_cinder_burn_effect.global_position = actor.get_follow_anchor_position() + Vector3(0.0, 0.35, 0.0)
+
+
+func _update_cinder_burn_effect(remaining_seconds: float, duration_seconds: float) -> void:
+	if _cinder_burn_effect == null or not is_instance_valid(_cinder_burn_effect):
+		return
+	var duration := maxf(duration_seconds, 0.05)
+	var elapsed := duration - remaining_seconds
+	var intensity := minf(1.0, elapsed / 0.75) * minf(1.0, remaining_seconds / 3.0)
+	for child in _cinder_burn_effect.get_children():
+		if child is MeshInstance3D and bool(child.get_meta("cinder_flame", false)):
+			var base_scale: Vector3 = child.get_meta("base_scale")
+			var base_position: Vector3 = child.get_meta("base_position")
+			var phase := float(child.get_meta("phase", 0.0))
+			var pulse := 0.72 + 0.28 * sin(elapsed * 9.0 + phase)
+			child.scale = base_scale * maxf(0.01, pulse * intensity)
+			child.position = base_position + Vector3(0.0, sin(elapsed * 7.0 + phase) * 0.08 * intensity, 0.0)
+			var material := child.material_override as StandardMaterial3D
+			if material != null:
+				var alpha := clampf(0.18 + 0.62 * intensity, 0.0, 0.82)
+				material.albedo_color.a = alpha
+				material.emission_energy_multiplier = 1.0 + 2.4 * intensity
+		elif child is MeshInstance3D and bool(child.get_meta("cinder_smoke", false)):
+			var base_scale: Vector3 = child.get_meta("base_scale")
+			var base_position: Vector3 = child.get_meta("base_position")
+			var phase := float(child.get_meta("phase", 0.0))
+			var drift := Vector3(cos(elapsed * 1.1 + phase), 0.0, sin(elapsed * 0.9 + phase)) * 0.08 * intensity
+			child.position = base_position + drift + Vector3(0.0, sin(elapsed * 1.7 + phase) * 0.08, 0.0)
+			child.scale = base_scale * (0.75 + 0.35 * intensity + 0.08 * sin(elapsed * 2.0 + phase))
+			var material := child.material_override as StandardMaterial3D
+			if material != null:
+				material.albedo_color.a = clampf(0.05 + 0.22 * intensity, 0.0, 0.28)
+		elif child is OmniLight3D and bool(child.get_meta("cinder_light", false)):
+			var light := child as OmniLight3D
+			light.light_energy = intensity * (1.4 + 0.8 * sin(elapsed * 12.0 + _cinder_burn_fire_seed))
+
+
+func _free_rustdead_visual_root_for_exit() -> void:
+	var visual_root := get_visual_root()
+	if visual_root == null:
+		return
+	_strip_meshes_for_exit(visual_root)
+	var parent := visual_root.get_parent()
+	if parent != null:
+		parent.remove_child(visual_root)
+	visual_root.free()
+
+
+func _strip_meshes_for_exit(root: Node) -> void:
+	if root == null:
+		return
+	if root is MeshInstance3D:
+		(root as MeshInstance3D).mesh = null
+	for child in root.get_children():
+		_strip_meshes_for_exit(child)
+
+
+func _apply_cinder_burn_overlay(root: Node) -> void:
+	if root == null:
+		return
+	if root is MeshInstance3D:
+		_apply_cinder_burn_overlay_to_mesh(root as MeshInstance3D)
+	for child in root.get_children():
+		_apply_cinder_burn_overlay(child)
+
+
+func _clear_cinder_burn_overlay(root: Node) -> void:
+	if root == null:
+		return
+	if root is MeshInstance3D:
+		var mesh_instance := root as MeshInstance3D
+		if mesh_instance.material_overlay != null and bool(mesh_instance.material_overlay.get_meta(CINDER_SCORCH_OVERLAY_META, false)):
+			mesh_instance.material_overlay = _get_cinder_burn_clear_material()
+		if mesh_instance.material_override != null and bool(mesh_instance.material_override.get_meta(CINDER_SCORCH_OVERLAY_META, false)):
+			mesh_instance.material_override = _get_cinder_burn_clear_material()
+	for child in root.get_children():
+		_clear_cinder_burn_overlay(child)
+
+
+func _apply_cinder_burn_overlay_to_mesh(mesh_instance: MeshInstance3D) -> void:
+	mesh_instance.material_override = _get_cinder_burn_overlay_material()
+
+
+func _node_has_cinder_burned_material(root: Node) -> bool:
+	if root == null:
+		return false
+	if root is MeshInstance3D and _mesh_has_cinder_burned_material(root as MeshInstance3D):
+		return true
+	for child in root.get_children():
+		if _node_has_cinder_burned_material(child):
+			return true
+	return false
+
+
+func _mesh_has_cinder_burned_material(mesh_instance: MeshInstance3D) -> bool:
+	if mesh_instance.material_overlay != null and bool(mesh_instance.material_overlay.get_meta(CINDER_BURNED_MATERIAL_META, false)):
+		return true
+	if mesh_instance.material_override != null and bool(mesh_instance.material_override.get_meta(CINDER_BURNED_MATERIAL_META, false)):
+		return true
+	for surface_index in range(mesh_instance.get_surface_override_material_count()):
+		var material := mesh_instance.get_surface_override_material(surface_index)
+		if material != null and bool(material.get_meta(CINDER_BURNED_MATERIAL_META, false)):
+			return true
+	return false
+
+
+func _get_cinder_burn_overlay_material() -> Material:
+	if _cinder_burn_overlay_material != null:
+		return _cinder_burn_overlay_material
+	var material := StandardMaterial3D.new()
+	material.resource_name = "Cinder Burn Overlay"
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	material.albedo_texture = _get_cinder_burn_overlay_texture()
+	material.albedo_color = Color(0.004, 0.0035, 0.003, 1.0)
+	material.roughness = 1.0
+	material.set_meta(CINDER_BURNED_MATERIAL_META, true)
+	material.set_meta(CINDER_SCORCH_OVERLAY_META, true)
+	_cinder_burn_overlay_material = material
+	return _cinder_burn_overlay_material
+
+
+func _get_cinder_burn_clear_material() -> Material:
+	var material := StandardMaterial3D.new()
+	material.resource_name = "Cleared Cinder Surface"
+	material.albedo_color = Color(0.02, 0.018, 0.015, 1.0)
+	material.roughness = 1.0
+	return material
+
+
+func _get_cinder_burn_overlay_texture() -> Texture2D:
+	if _cinder_burn_overlay_texture != null:
+		return _cinder_burn_overlay_texture
+	var size := 128
+	var image := Image.create(size, size, false, Image.FORMAT_RGBA8)
+	for y in range(size):
+		for x in range(size):
+			var uv := Vector2(float(x) / float(size - 1), float(y) / float(size - 1))
+			var mask := _get_cinder_burn_overlay_mask(uv, x, y)
+			var ash := _cinder_overlay_noise01(x, y, 29)
+			var shade := 0.006 + ash * 0.028
+			var color := Color(shade, shade * 0.9, shade * 0.78, mask)
+			if mask > 0.58 and _cinder_overlay_noise01(x, y, 53) > 0.88:
+				color = Color(0.18, 0.16, 0.13, mask * 0.86)
+			image.set_pixel(x, y, color)
+	_cinder_burn_overlay_texture = ImageTexture.create_from_image(image)
+	return _cinder_burn_overlay_texture
+
+
+func _get_cinder_burn_overlay_mask(uv: Vector2, x: int, y: int) -> float:
+	var center := uv - Vector2(0.5, 0.5)
+	var radial := maxf(0.0, 1.0 - center.length() / 0.92)
+	var lobe_a := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.32, 0.62)) / 0.52)
+	var lobe_b := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.68, 0.38)) / 0.48)
+	var lobe_c := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.55, 0.77)) / 0.44)
+	var lobe_d := maxf(0.0, 1.0 - uv.distance_to(Vector2(0.46, 0.28)) / 0.36)
+	var crack := 0.5 + 0.5 * sin((uv.x * 15.0 + uv.y * 8.0 + _cinder_overlay_noise01(x, y, 7) * 2.0) * PI)
+	var grain := _cinder_overlay_noise01(x, y, 13)
+	var mask := radial * 0.7 + lobe_a * 0.46 + lobe_b * 0.44 + lobe_c * 0.34 + lobe_d * 0.26 + crack * 0.2 + grain * 0.24 - 0.13
+	mask = clampf(mask, 0.0, 1.0)
+	return mask * mask * (3.0 - 2.0 * mask)
+
+
+func _cinder_overlay_noise01(x: int, y: int, salt: int) -> float:
+	var value := sin(float(x * 23 + salt * 41) * 12.9898 + float(y * 31 + salt * 17) * 78.233) * 43758.5453
+	return value - floor(value)

--- a/scripts/validation/validate_rustdead_nests.gd
+++ b/scripts/validation/validate_rustdead_nests.gd
@@ -1,11 +1,14 @@
 extends SceneTree
 
-const DEMO_WORLD_SCENE := preload("res://scenes/worlds/demo_world/demo_world.tscn")
-const RUSTDEAD_NEST_TYPE := preload("res://resources/world_sim/nests/rustdead.tres")
+const DEMO_WORLD_SCENE_PATH := "res://scenes/worlds/demo_world/demo_world.tscn"
+const RUSTDEAD_NEST_TYPE_PATH := "res://resources/world_sim/nests/rustdead.tres"
 const ANCIENT_VENT_SCENE_PATH := "res://scenes/world/nests/rustdead/ancient_vent_01.tscn"
-const AI_JOB_SCRIPT := preload("res://scripts/ai/ai_job.gd")
-const AI_PATROL_STEP_SCRIPT := preload("res://scripts/ai/steps/ai_patrol_step.gd")
-const AI_NEST_ASSAULT_STEP_SCRIPT := preload("res://scripts/ai/steps/ai_nest_assault_step.gd")
+const AI_JOB_SCRIPT_PATH := "res://scripts/ai/ai_job.gd"
+const AI_PATROL_STEP_SCRIPT_PATH := "res://scripts/ai/steps/ai_patrol_step.gd"
+const AI_NEST_ASSAULT_STEP_SCRIPT_PATH := "res://scripts/ai/steps/ai_nest_assault_step.gd"
+const AI_UTILITY_ADAPTER_PATH := "res://scripts/ai/utility/ai_utility_adapter.gd"
+const COMBAT_COORDINATOR_PATH := "res://scripts/characters/combat_coordinator.gd"
+const SKIN_TEXTURE_BUILDER_PATH := "res://scripts/character_appearance/skin_texture_builder.gd"
 
 const WEST_MARKER_ID := "demo_rustdead_west_vent"
 const PATROL_SOURCE_ID := "nest_patrol"
@@ -14,7 +17,7 @@ const NEST_VISUAL_NAME := "ActiveNestVisual"
 const NEST_INTERACTION_BODY_NAME := "NestInteractionBody"
 const NEST_SCRAP_ROOT_NAME := "NestScrapPiles"
 const VISUAL_BODY_TYPE_MALE := 2
-const RUSTDEAD_TIER_LIBRARY := preload("res://scripts/characters/rustdead_tier_library.gd")
+const RUSTDEAD_TIER_LIBRARY_PATH := "res://scripts/characters/rustdead_tier_library.gd"
 const MAX_VISUAL_FOOT_SINK := 0.035
 const WROUGHT_MIN_SKIN_METALLIC := 0.30
 const ANCIENT_MIN_SKIN_METALLIC := 0.58
@@ -31,16 +34,27 @@ func _initialize() -> void:
 func _run() -> void:
 	_validate_nest_type_definition()
 	_validate_ai_job_contract()
-	_scene = DEMO_WORLD_SCENE.instantiate()
+	var demo_world_scene := load(DEMO_WORLD_SCENE_PATH) as PackedScene
+	if demo_world_scene == null:
+		_fail("Demo world scene should load from %s" % DEMO_WORLD_SCENE_PATH)
+		_print_failures_and_quit()
+		return
+	_scene = demo_world_scene.instantiate()
+	demo_world_scene = null
 	root.add_child(_scene)
 	await _wait_frames(180)
 	_validate_demo_markers()
 	_validate_controller_runtime()
 	await _validate_assault_job_start()
+	await _cleanup_scene()
 	if _failures.is_empty():
 		print("RUSTDEAD_NESTS_OK")
 		quit(0)
 		return
+	_print_failures_and_quit()
+
+
+func _print_failures_and_quit() -> void:
 	for failure in _failures:
 		push_error(failure)
 	print("RUSTDEAD_NESTS_FAILED count=%d" % _failures.size())
@@ -48,27 +62,31 @@ func _run() -> void:
 
 
 func _validate_nest_type_definition() -> void:
-	if str(RUSTDEAD_NEST_TYPE.call("get_id")) != "rustdead":
+	var rustdead_nest_type := _load_rustdead_nest_type()
+	if rustdead_nest_type == null:
+		_fail("Rustdead nest type should load from %s" % RUSTDEAD_NEST_TYPE_PATH)
+		return
+	if str(rustdead_nest_type.call("get_id")) != "rustdead":
 		_fail("Rustdead nest type should use stable id rustdead")
-	if float(RUSTDEAD_NEST_TYPE.get("default_initial_activation_chance")) != 0.5:
+	if float(rustdead_nest_type.get("default_initial_activation_chance")) != 0.5:
 		_fail("Rustdead nest default activation chance should be 50%")
-	if int(RUSTDEAD_NEST_TYPE.get("small_population_min")) != 8 or int(RUSTDEAD_NEST_TYPE.get("small_population_max")) != 12:
+	if int(rustdead_nest_type.get("small_population_min")) != 8 or int(rustdead_nest_type.get("small_population_max")) != 12:
 		_fail("Small Rustdead nest population should be 8-12")
-	if int(RUSTDEAD_NEST_TYPE.get("small_patrol_squad_count")) != 2:
+	if int(rustdead_nest_type.get("small_patrol_squad_count")) != 2:
 		_fail("Small Rustdead nest should define 2 patrol squads")
-	if int(RUSTDEAD_NEST_TYPE.get("small_patrol_squad_min")) != 3 or int(RUSTDEAD_NEST_TYPE.get("small_patrol_squad_max")) != 5:
+	if int(rustdead_nest_type.get("small_patrol_squad_min")) != 3 or int(rustdead_nest_type.get("small_patrol_squad_max")) != 5:
 		_fail("Small Rustdead patrol squad size should be 3-5")
-	if int(RUSTDEAD_NEST_TYPE.get("small_attack_squad_min")) != 3 or int(RUSTDEAD_NEST_TYPE.get("small_attack_squad_max")) != 7:
+	if int(rustdead_nest_type.get("small_attack_squad_min")) != 3 or int(rustdead_nest_type.get("small_attack_squad_max")) != 7:
 		_fail("Small Rustdead attack squad size should be 3-7")
-	if float(RUSTDEAD_NEST_TYPE.get("wander_radius")) != 500.0:
+	if float(rustdead_nest_type.get("wander_radius")) != 500.0:
 		_fail("Rustdead wander radius should be 500m")
-	if float(RUSTDEAD_NEST_TYPE.get("attack_radius")) != 1000.0:
+	if float(rustdead_nest_type.get("attack_radius")) != 1000.0:
 		_fail("Rustdead attack radius should be 1000m")
-	if float(RUSTDEAD_NEST_TYPE.get("daily_attack_chance")) != 0.05:
+	if float(rustdead_nest_type.get("daily_attack_chance")) != 0.05:
 		_fail("Rustdead daily attack chance should be 5%")
-	if int(RUSTDEAD_NEST_TYPE.get("respawn_cooldown_days")) != 7:
+	if int(rustdead_nest_type.get("respawn_cooldown_days")) != 7:
 		_fail("Destroyed Rustdead nests should become eligible after about 7 days")
-	var visual_scenes: Array = RUSTDEAD_NEST_TYPE.get("visual_scenes") if RUSTDEAD_NEST_TYPE.get("visual_scenes") is Array else []
+	var visual_scenes: Array = rustdead_nest_type.get("visual_scenes") if rustdead_nest_type.get("visual_scenes") is Array else []
 	if visual_scenes.is_empty():
 		_fail("Rustdead nest type should define authored visual scene variants")
 	elif visual_scenes[0] == null or str((visual_scenes[0] as PackedScene).resource_path) != ANCIENT_VENT_SCENE_PATH:
@@ -76,21 +94,27 @@ func _validate_nest_type_definition() -> void:
 
 
 func _validate_ai_job_contract() -> void:
-	if AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.PATROL) <= AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.AMBIENT_ACTIVITY):
+	var ai_job_script = load(AI_JOB_SCRIPT_PATH)
+	var ai_patrol_step_script = load(AI_PATROL_STEP_SCRIPT_PATH)
+	var ai_nest_assault_step_script = load(AI_NEST_ASSAULT_STEP_SCRIPT_PATH)
+	if ai_job_script == null or ai_patrol_step_script == null or ai_nest_assault_step_script == null:
+		_fail("AI job scripts should load for Rustdead nest validation")
+		return
+	if ai_job_script.priority_for_type(ai_job_script.JobType.PATROL) <= ai_job_script.priority_for_type(ai_job_script.JobType.AMBIENT_ACTIVITY):
 		_fail("Patrol jobs should outrank ambient activity")
-	if AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.NEST_ASSAULT) <= AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.PATROL):
+	if ai_job_script.priority_for_type(ai_job_script.JobType.NEST_ASSAULT) <= ai_job_script.priority_for_type(ai_job_script.JobType.PATROL):
 		_fail("Nest assault jobs should outrank patrol jobs")
-	if AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.NEST_ASSAULT) >= AI_JOB_SCRIPT.priority_for_type(AI_JOB_SCRIPT.JobType.SELF_DEFENSE):
+	if ai_job_script.priority_for_type(ai_job_script.JobType.NEST_ASSAULT) >= ai_job_script.priority_for_type(ai_job_script.JobType.SELF_DEFENSE):
 		_fail("Self-defense should be able to interrupt nest assault jobs")
-	var job = AI_JOB_SCRIPT.new()
-	job.job_type = AI_JOB_SCRIPT.JobType.PATROL
+	var job = ai_job_script.new()
+	job.job_type = ai_job_script.JobType.PATROL
 	job.data = {"marker_id": "test_marker"}
 	if str(job.get_debug_snapshot().get("data", {}).get("marker_id", "")) != "test_marker":
 		_fail("AiJob debug snapshots should expose job data payloads")
-	var patrol_step = AI_PATROL_STEP_SCRIPT.new()
+	var patrol_step = ai_patrol_step_script.new()
 	if str(patrol_step.get("step_id")) != "patrol":
 		_fail("Patrol AI step should identify as patrol")
-	var assault_step = AI_NEST_ASSAULT_STEP_SCRIPT.new()
+	var assault_step = ai_nest_assault_step_script.new()
 	if str(assault_step.get("step_id")) != "nest_assault":
 		_fail("Nest assault AI step should identify as nest_assault")
 
@@ -248,12 +272,16 @@ func _validate_rustdead_actor_tier(actor: Node, actor_id: String) -> void:
 
 
 func _validate_rustdead_actor_skill_ranges(actor: Node, tier: Resource, actor_id: String) -> void:
+	var rustdead_tier_library = _load_rustdead_tier_library()
+	if rustdead_tier_library == null:
+		_fail("Rustdead tier library should load from %s" % RUSTDEAD_TIER_LIBRARY_PATH)
+		return
 	var tier_range: Vector2i = tier.call("get_stat_range")
-	var non_tier_range := RUSTDEAD_TIER_LIBRARY.get_non_tier_skill_range()
+	var non_tier_range: Vector2i = rustdead_tier_library.get_non_tier_skill_range()
 	for definition in SkillRules.get_all_definitions():
 		var actual := int(actor.call("get_skill_level", definition.skill_id))
-		var expected_range := tier_range if RUSTDEAD_TIER_LIBRARY.is_tier_scaled_skill_id(definition.skill_id) else non_tier_range
-		var range_label := "tier" if RUSTDEAD_TIER_LIBRARY.is_tier_scaled_skill_id(definition.skill_id) else "non-tier Rustdead"
+		var expected_range := tier_range if rustdead_tier_library.is_tier_scaled_skill_id(definition.skill_id) else non_tier_range
+		var range_label := "tier" if rustdead_tier_library.is_tier_scaled_skill_id(definition.skill_id) else "non-tier Rustdead"
 		if actual < expected_range.x or actual > expected_range.y:
 			_fail("Spawned Rustdead actor %s skill %s should be in %s range %d-%d, got %d" % [actor_id, definition.skill_id, range_label, expected_range.x, expected_range.y, actual])
 			return
@@ -266,7 +294,11 @@ func _validate_rustdead_actor_skill_ranges(actor: Node, tier: Resource, actor_id
 
 
 func _validate_ancient_non_tier_actor_skill_is_low(actor: Node, actor_id: String, skill_id: String) -> void:
-	var non_tier_range := RUSTDEAD_TIER_LIBRARY.get_non_tier_skill_range()
+	var rustdead_tier_library = _load_rustdead_tier_library()
+	if rustdead_tier_library == null:
+		_fail("Rustdead tier library should load from %s" % RUSTDEAD_TIER_LIBRARY_PATH)
+		return
+	var non_tier_range: Vector2i = rustdead_tier_library.get_non_tier_skill_range()
 	var actual := int(actor.call("get_skill_level", skill_id))
 	if actual > non_tier_range.y:
 		_fail("Spawned Ancient Rustdead actor %s should not scale non-physical skill %s above %d, got %d" % [actor_id, skill_id, non_tier_range.y, actual])
@@ -286,14 +318,18 @@ func _validate_rustdead_actor_blood(actor: Node, actor_id: String) -> void:
 
 
 func _validate_rustdead_actor_feet(actor: Node, actor_id: String) -> void:
-	if not actor.has_method("get_visual_foot_anchor_y") or not actor.has_method("get_visual_ground_y"):
+	if not actor.has_method("get_body_projection"):
 		_fail("Spawned Rustdead actor %s should expose visual foot anchors" % actor_id)
 		return
-	var foot_y := float(actor.call("get_visual_foot_anchor_y"))
+	var body = actor.call("get_body_projection")
+	if body == null or not body.has_method("get_visual_foot_anchor_y") or not body.has_method("get_visual_ground_y"):
+		_fail("Spawned Rustdead actor %s should expose visual foot anchors" % actor_id)
+		return
+	var foot_y := float(body.call("get_visual_foot_anchor_y"))
 	if foot_y == INF:
 		_fail("Spawned Rustdead actor %s should expose a valid visual foot anchor" % actor_id)
 		return
-	var ground_y := float(actor.call("get_visual_ground_y"))
+	var ground_y := float(body.call("get_visual_ground_y"))
 	if foot_y < ground_y - MAX_VISUAL_FOOT_SINK:
 		_fail("Spawned Rustdead actor %s visual feet should not sink below ground: foot=%.3f ground=%.3f" % [actor_id, foot_y, ground_y])
 
@@ -393,6 +429,7 @@ func _validate_scrap_specs_for_all_nest_sizes(nest_controller: Node) -> void:
 			_fail("Medium Rustdead nest should guarantee at least one large scavenge pile")
 		if size_id == "large" and large_count < 2:
 			_fail("Large Rustdead nest should guarantee at least two large scavenge piles")
+		marker.free()
 
 
 func _expected_scrap_count_range(size_id: String) -> Vector2i:
@@ -425,7 +462,11 @@ func _validate_attack_target_selection(nest_controller: Node) -> void:
 	var marker := _scene.get_node_or_null("NestMarkers/RustdeadWestVent") as Node3D
 	if marker == null:
 		return
-	var target_id := str(nest_controller.call("_find_attack_target_settlement", marker.global_position, 1000.0, str(RUSTDEAD_NEST_TYPE.call("get_faction_id"))))
+	var rustdead_nest_type := _load_rustdead_nest_type()
+	if rustdead_nest_type == null:
+		_fail("Rustdead nest type should load from %s" % RUSTDEAD_NEST_TYPE_PATH)
+		return
+	var target_id := str(nest_controller.call("_find_attack_target_settlement", marker.global_position, 1000.0, str(rustdead_nest_type.call("get_faction_id"))))
 	if target_id != "surf_city":
 		_fail("West Rustdead nest should target closest non-Rustdead settlement surf_city, got %s" % target_id)
 
@@ -446,7 +487,13 @@ func _validate_assault_job_start() -> void:
 	var before_actor_count := before_actor_ids.size()
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 424242
-	if not bool(nest_controller.call("_start_settlement_attack", marker, state, RUSTDEAD_NEST_TYPE, 42, rng)):
+	var rustdead_nest_type := _load_rustdead_nest_type()
+	if rustdead_nest_type == null:
+		_fail("Rustdead nest type should load from %s" % RUSTDEAD_NEST_TYPE_PATH)
+		return
+	var started := bool(nest_controller.call("_start_settlement_attack", marker, state, rustdead_nest_type, 42, rng))
+	rustdead_nest_type = null
+	if not started:
 		_fail("Rustdead nest should be able to start an assault against the closest settlement")
 		return
 	await _wait_frames(10)
@@ -498,6 +545,37 @@ func _get_controller(group_name: String) -> Node:
 func _wait_frames(count: int) -> void:
 	for _i in range(count):
 		await process_frame
+
+
+func _cleanup_scene() -> void:
+	if _scene != null and is_instance_valid(_scene):
+		root.remove_child(_scene)
+		_scene.free()
+	_scene = null
+	await process_frame
+	await physics_frame
+	_cleanup_runtime_state()
+	await process_frame
+
+
+func _cleanup_runtime_state() -> void:
+	var combat_coordinator = load(COMBAT_COORDINATOR_PATH)
+	if combat_coordinator != null and combat_coordinator.has_method("reset_all_state"):
+		combat_coordinator.reset_all_state()
+	var ai_utility_adapter = load(AI_UTILITY_ADAPTER_PATH)
+	if ai_utility_adapter != null and ai_utility_adapter.has_method("clear_runtime_caches"):
+		ai_utility_adapter.clear_runtime_caches()
+	var skin_texture_builder = load(SKIN_TEXTURE_BUILDER_PATH)
+	if skin_texture_builder != null and skin_texture_builder.has_method("clear_runtime_caches"):
+		skin_texture_builder.clear_runtime_caches()
+
+
+func _load_rustdead_nest_type() -> Resource:
+	return load(RUSTDEAD_NEST_TYPE_PATH) as Resource
+
+
+func _load_rustdead_tier_library():
+	return load(RUSTDEAD_TIER_LIBRARY_PATH)
 
 
 func _fail(message: String) -> void:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Rustdead character cinder burn visual effect management to use a centralized projection system for improved code maintainability and consistency.

* **Chores**
  * Improved validation system for nest configuration with enhanced runtime resource loading and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->